### PR TITLE
Improve CPU trapping for watchpoints

### DIFF
--- a/Cpu.c
+++ b/Cpu.c
@@ -1179,7 +1179,6 @@ void SetCoreToRunning  ( void ) {
 
 void SetCoreToStepping ( void ) {
 	CPU_Action.Stepping = TRUE;
-	CPU_Action.DoSomething = FALSE;
 }
 
 void SetCoreToSkipping(void) {

--- a/Interpreter CPU.h
+++ b/Interpreter CPU.h
@@ -27,6 +27,6 @@ void BuildInterpreter         ( void );
 void ExecuteInterpreterOpCode ( void );
 void __cdecl StartInterpreterCPU      ( void );
 void TestInterpreterJump      ( DWORD PC, DWORD TargetPC, int Reg1, int Reg2 );
-void TriggerDebugger(BOOL IsWatchPoint);
+void TriggerDebugger(void);
 
 extern void (__fastcall *R4300i_Opcode[64])(void);

--- a/Memory.c
+++ b/Memory.c
@@ -1456,7 +1456,6 @@ BOOL r4300i_LB_VAddr ( DWORD VAddr, BYTE * Value ) {
 
 BOOL r4300i_LD_VAddr ( DWORD VAddr, unsigned _int64 * Value ) {
 	CheckForWatchPoint(VAddr, READ);
-	CheckForWatchPoint(VAddr + 4, READ);
 
 	if (TLB_ReadMap[VAddr >> 12] == 0) { return FALSE; }
 	*((DWORD *)(Value) + 1) = *(DWORD *)(TLB_ReadMap[VAddr >> 12] + VAddr);
@@ -1850,7 +1849,6 @@ int r4300i_SH_NonMemory ( DWORD PAddr, WORD Value ) {
 
 BOOL r4300i_SD_VAddr ( DWORD VAddr, unsigned _int64 Value ) {
 	CheckForWatchPoint(VAddr, WRITE);
-	CheckForWatchPoint(VAddr + 4, WRITE);
 
 	if (TLB_WriteMap[VAddr >> 12] == 0) { return FALSE; }
 	*(DWORD *)(TLB_WriteMap[VAddr >> 12] + VAddr) = *((DWORD *)(&Value) + 1);

--- a/WatchPoints.cpp
+++ b/WatchPoints.cpp
@@ -73,7 +73,11 @@ BOOL CheckForWatchPoint(DWORD Location, WATCH_TYPE Type) {
 
 	int value = search->second;
 	if (value & (int)Type) {
-		TriggerDebugger(TRUE);
+		TriggerDebugger();
+
+		// Block the CPU thread until resumed by the debugger
+		WaitForSingleObject(CPU_Action.hStepping, INFINITE);
+
 		return TRUE;
 	}
 


### PR DESCRIPTION
Block the CPU thread when a watchpoint is hit. This moves the blocking to just before the memory access happens. Allows removing the gross hacks that changed CPU interpreter flow control.

Removes unnecessary double-watchpoint checks in LD and SD instructions.