### PR TITLE
Debugger improvements

### DIFF
--- a/BreakPoints.c
+++ b/BreakPoints.c
@@ -405,6 +405,7 @@ void RemoveR4300iBreakPoint (DWORD Location) {
 		}
 		NoOfBpoints -= 1;
 		RefreshBreakPoints ();
+		RefreshR4300iCommands();
 	}
 
 	/*if (CPU_Action.Stepping || hMipsCPU == NULL) {

--- a/BreakPoints.c
+++ b/BreakPoints.c
@@ -400,6 +400,7 @@ void RemoveR4300iBreakPoint (DWORD Location) {
 
 	if (location >= 0) {
 		for (count = location; count < NoOfBpoints - 1; count ++ ){
+			BPoint[count].enabled = BPoint[count + 1].enabled;
 			BPoint[count].Location = BPoint[count + 1].Location;
 		}
 		NoOfBpoints -= 1;

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -744,7 +744,7 @@ void __cdecl StartInterpreterCPU (void ) {
 		for (;;) {
 			if (HaveDebugger) {
 				if (NoOfBpoints != 0 && CheckForR4300iBPoint(PROGRAM_COUNTER)) {
-					TriggerDebugger(FALSE);
+					TriggerDebugger();
 				}
 
 				if (CPU_Action.Stepping) {

--- a/Main.c
+++ b/Main.c
@@ -1762,7 +1762,7 @@ int RegisterWinClass(void) {
 	if (RegisterClass(&wcl) == 0) return FALSE;
 
 	wcl.lpfnWndProc = (WNDPROC)Cheat_Proc;
-	wcl.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
+	wcl.hbrBackground = GetSysColorBrush(COLOR_BTNFACE);
 	wcl.lpszMenuName = NULL;
 	wcl.lpszClassName = "PJ64.Cheats";
 	if (RegisterClass(&wcl) == 0) return FALSE;

--- a/Memory.c
+++ b/Memory.c
@@ -1447,7 +1447,7 @@ int r4300i_LB_NonMemory ( DWORD PAddr, DWORD * Value, BOOL SignExtend ) {
 }
 
 BOOL r4300i_LB_VAddr ( DWORD VAddr, BYTE * Value ) {
-	CheckForWatchPoint(VAddr, WP_READ);
+	CheckForWatchPoint(VAddr, WP_READ, sizeof(BYTE));
 
 	if (TLB_ReadMap[VAddr >> 12] == 0) { return FALSE; }
 	*Value = *(BYTE *)(TLB_ReadMap[VAddr >> 12] + (VAddr ^ 3));
@@ -1461,7 +1461,7 @@ BOOL r4300i_LB_VAddr_NonCPU ( DWORD VAddr, BYTE * Value ) {
 }
 
 BOOL r4300i_LD_VAddr ( DWORD VAddr, unsigned _int64 * Value ) {
-	CheckForWatchPoint(VAddr, WP_READ);
+	CheckForWatchPoint(VAddr, WP_READ, sizeof(unsigned _int64));
 
 	if (TLB_ReadMap[VAddr >> 12] == 0) { return FALSE; }
 	*((DWORD *)(Value) + 1) = *(DWORD *)(TLB_ReadMap[VAddr >> 12] + VAddr);
@@ -1487,7 +1487,7 @@ int r4300i_LH_NonMemory ( DWORD PAddr, DWORD * Value, int SignExtend ) {
 }
 
 BOOL r4300i_LH_VAddr ( DWORD VAddr, WORD * Value ) {
-	CheckForWatchPoint(VAddr, WP_READ);
+	CheckForWatchPoint(VAddr, WP_READ, sizeof(WORD));
 
 	if (TLB_ReadMap[VAddr >> 12] == 0) { return FALSE; }
 	*Value = *(WORD *)(TLB_ReadMap[VAddr >> 12] + (VAddr ^ 2));
@@ -1761,7 +1761,7 @@ void r4300i_LW_PAddr ( DWORD PAddr, DWORD * Value ) {
 }
 
 BOOL r4300i_LW_VAddr ( DWORD VAddr, DWORD * Value ) {
-	CheckForWatchPoint(VAddr, WP_READ);
+	CheckForWatchPoint(VAddr, WP_READ, sizeof(DWORD));
 
 	if (TLB_ReadMap[VAddr >> 12] == 0) { return FALSE; }
 	*Value = *(DWORD *)(TLB_ReadMap[VAddr >> 12] + VAddr);
@@ -1816,7 +1816,7 @@ int r4300i_SB_NonMemory ( DWORD PAddr, BYTE Value ) {
 }
 
 BOOL r4300i_SB_VAddr ( DWORD VAddr, BYTE Value ) {
-	CheckForWatchPoint(VAddr, WP_WRITE);
+	CheckForWatchPoint(VAddr, WP_WRITE, sizeof(BYTE));
 
 	if (TLB_WriteMap[VAddr >> 12] == 0) { return FALSE; }
 	*(BYTE *)(TLB_WriteMap[VAddr >> 12] + (VAddr ^ 3)) = Value;
@@ -1872,7 +1872,7 @@ int r4300i_SH_NonMemory ( DWORD PAddr, WORD Value ) {
 }
 
 BOOL r4300i_SD_VAddr ( DWORD VAddr, unsigned _int64 Value ) {
-	CheckForWatchPoint(VAddr, WP_WRITE);
+	CheckForWatchPoint(VAddr, WP_WRITE, sizeof(unsigned _int64));
 
 	if (TLB_WriteMap[VAddr >> 12] == 0) { return FALSE; }
 	*(DWORD *)(TLB_WriteMap[VAddr >> 12] + VAddr) = *((DWORD *)(&Value) + 1);
@@ -1881,7 +1881,7 @@ BOOL r4300i_SD_VAddr ( DWORD VAddr, unsigned _int64 Value ) {
 }
 
 BOOL r4300i_SH_VAddr ( DWORD VAddr, WORD Value ) {
-	CheckForWatchPoint(VAddr, WP_WRITE);
+	CheckForWatchPoint(VAddr, WP_WRITE, sizeof(WORD));
 
 	if (TLB_WriteMap[VAddr >> 12] == 0) { return FALSE; }
 	*(WORD *)(TLB_WriteMap[VAddr >> 12] + (VAddr ^ 2)) = Value;
@@ -2299,7 +2299,7 @@ int r4300i_SW_NonMemory ( DWORD PAddr, DWORD Value ) {
 }
 
 BOOL r4300i_SW_VAddr ( DWORD VAddr, DWORD Value ) {
-	CheckForWatchPoint(VAddr, WP_WRITE);
+	CheckForWatchPoint(VAddr, WP_WRITE, sizeof(DWORD));
 
 	if (TLB_WriteMap[VAddr >> 12] == 0) { return FALSE; }
 	*(DWORD *)(TLB_WriteMap[VAddr >> 12] + VAddr) = Value;

--- a/Registers.c
+++ b/Registers.c
@@ -72,10 +72,10 @@ char *FPR_Ctrl_Name[32] = {"Revision","Unknown","Unknown","Unknown","Unknown",
 					"Unknown","Unknown","Unknown","Unknown","Unknown","Unknown",
 					"Unknown","Unknown","FCSR"};
 
-char *Cop0_Name[32] = {"Index","Random","EntryLo0","EntryLo1","Context","PageMask","Wired","",
+char *Cop0_Name[32] = {"Index","Random","EntryLo0","EntryLo1","Context","PageMask","Wired","7",
                     "BadVAddr","Count","EntryHi","Compare","Status","Cause","EPC","PRId",
-                    "Config","LLAddr","WatchLo","WatchHi","XContext","","","",
-                    "","","ECC","CacheErr","TagLo","TagHi","ErrEPC",""};
+                    "Config","LLAddr","WatchLo","WatchHi","XContext","21","22","23",
+                    "24","25","ECC","CacheErr","TagLo","TagHi","ErrEPC","31"};
 
 DWORD PROGRAM_COUNTER, * CP0,*FPCR,*RegRDRAM,*RegSP,*RegDPC,*RegMI,*RegVI,*RegAI,*RegPI,
 	*RegRI,*RegSI, HalfLine, RegModValue, ViFieldSerration, LLBit, LLAddr;

--- a/Registers.h
+++ b/Registers.h
@@ -322,8 +322,8 @@
 #define	FPCSR_RM_RP				0x00000002	/* round to positive infinity */
 #define	FPCSR_RM_RM				0x00000003	/* round to negative infinity */
 
-#define FPR_Type(Reg)	(Reg) == R4300i_COP1_S ? "S" : (Reg) == R4300i_COP1_D ? "D" :\
-						(Reg) == R4300i_COP1_W ? "W" : "L"
+#define FPR_Type(Reg)	(Reg) == R4300i_COP1_S ? "s" : (Reg) == R4300i_COP1_D ? "d" :\
+						(Reg) == R4300i_COP1_W ? "w" : "l"
 
 typedef struct {
 	DWORD      PROGRAM_COUNTER;

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -875,7 +875,7 @@ void RomListDrawItem(LPDRAWITEMSTRUCT ditem) {
 		SetTextColor(ditem->hDC, GetColor(pRomInfo->Status, COLOR_SELECTED_TEXT));
 	}
 	else {
-		hBrush = (HBRUSH)(COLOR_WINDOW + 1);
+		hBrush = GetSysColorBrush(COLOR_WINDOW);
 		SetTextColor(ditem->hDC, GetColor(pRomInfo->Status, COLOR_TEXT));
 	}
 	FillRect(ditem->hDC, &ditem->rcItem, hBrush);

--- a/WatchPoints.h
+++ b/WatchPoints.h
@@ -40,7 +40,7 @@ void RemoveWatchPoint(DWORD Location);
 void ToggleWatchPoint(DWORD Location);
 void RemoveAllWatchPoints(void);
 WATCH_TYPE HasWatchPoint(DWORD Location);
-BOOL CheckForWatchPoint(DWORD Location, WATCH_TYPE Type);
+BOOL CheckForWatchPoint(DWORD Location, WATCH_TYPE Type, int Size);
 int CountWatchPoints(void);
 void RefreshWatchPoints(HWND hList);
 

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -225,7 +225,7 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 		
 	if (PROGRAM_COUNTER == r4300iCommandLine[ditem->itemID].Location) {
 		ResetColor = TRUE;
-		hBrush     = (HBRUSH)(COLOR_HIGHLIGHT + 1);
+		hBrush     = GetSysColorBrush(COLOR_HIGHLIGHT);
 		oldColor   = SetTextColor(ditem->hDC,RGB(255,255,255));
 	} else {
 		ResetColor = FALSE;
@@ -312,7 +312,7 @@ void Paint_R4300i_Commands (HWND hDlg) {
 	PAINTSTRUCT ps;
 	RECT rcBox;
 	HFONT hOldFont;
-	int OldBkMode;
+	COLORREF OldBkColor;
 
 	BeginPaint( hDlg, &ps );
 		
@@ -330,7 +330,6 @@ void Paint_R4300i_Commands (HWND hDlg) {
 		
 	rcBox.left   = 422; rcBox.top    = 2;
 	rcBox.right  = 470; rcBox.bottom = 15;
-	FillRect( ps.hdc, &rcBox,(HBRUSH)COLOR_WINDOW);
 		
 	if (NoOfMapEntries) {
 		rcBox.left   = 417; rcBox.top    = 49;
@@ -339,7 +338,6 @@ void Paint_R4300i_Commands (HWND hDlg) {
 		
 		rcBox.left   = 422; rcBox.top    = 44;
 		rcBox.right  = 460; rcBox.bottom = 57;
-		FillRect( ps.hdc, &rcBox,(HBRUSH)COLOR_WINDOW);
 	}
 
 	rcBox.left   = 14; rcBox.top    = 14;
@@ -355,7 +353,7 @@ void Paint_R4300i_Commands (HWND hDlg) {
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED , BF_RECT );
 
 	hOldFont = (HFONT)SelectObject( ps.hdc,GetStockObject(DEFAULT_GUI_FONT ) );
-	OldBkMode = SetBkMode( ps.hdc, TRANSPARENT );
+	OldBkColor = SetBkColor(ps.hdc, GetSysColor(COLOR_BTNFACE));
 		
 	TextOut( ps.hdc, 23,16,"Offset",6);
 	TextOut( ps.hdc, 119,16,"Instruction",11);
@@ -364,11 +362,11 @@ void Paint_R4300i_Commands (HWND hDlg) {
 	TextOut( ps.hdc, 424,19,"0x",2);
 	
 	if (NoOfMapEntries) {
-		TextOut( ps.hdc, 424,44," goto:",6);
+		TextOut( ps.hdc, 424,44," goto: ",7);
 	}
 
 	SelectObject( ps.hdc,hOldFont );
-	SetBkMode( ps.hdc, OldBkMode );
+	SetBkColor( ps.hdc, OldBkColor );
 		
 	EndPaint( hDlg, &ps );
 }

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -576,6 +576,7 @@ LRESULT CALLBACK R4300i_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
 				break;
 			case IDC_GO_BUTTON:
 				SetR4300iCommandToRunning();
+				RefreshR4300iCommands();
 				break;
 			case IDC_BREAK_BUTTON:
 				SetR4300iCommandToStepping();

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -758,7 +758,7 @@ void R4300i_Commands_Setup ( HWND hDlg ) {
 	} 
 
 	hGoButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Go", WS_CHILD |
-		BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, 417,56,100,24, hDlg,(HMENU)IDC_GO_BUTTON,
+		BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, 505,56,100,24, hDlg,(HMENU)IDC_GO_BUTTON,
 		hInst,NULL );
 	if (hGoButton) {
 		SendMessage(hGoButton,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -894,16 +894,16 @@ char * R4300iCop1Name ( DWORD OpCode, DWORD PC ) {
 	case R4300i_COP1_BC:
 		switch (command.FP.ft) {
 		case R4300i_COP1_BC_BCF:
-			sprintf(CommandName,"BC1F\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
+			sprintf(CommandName,"bc1f\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
 			break;
 		case R4300i_COP1_BC_BCT:
-			sprintf(CommandName,"BC1T\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
+			sprintf(CommandName,"bc1t\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
 			break;
 		case R4300i_COP1_BC_BCFL:
-			sprintf(CommandName,"BC1FL\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
+			sprintf(CommandName,"bc1fl\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
 			break;
 		case R4300i_COP1_BC_BCTL:
-			sprintf(CommandName,"BC1TL\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
+			sprintf(CommandName,"bc1tl\t%s", LabelName(PC + ((short)command.BRANCH.offset << 2) + 4));
 			break;
 		default:
 			sprintf(CommandName,"Unknown Cop1\t%02X %02X %02X %02X",
@@ -916,151 +916,151 @@ char * R4300iCop1Name ( DWORD OpCode, DWORD PC ) {
 	case R4300i_COP1_L:
 		switch (command.REG.funct) {			
 		case R4300i_COP1_FUNCT_ADD:
-			sprintf(CommandName,"ADD.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"add.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs], 
 				FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_SUB:
-			sprintf(CommandName,"SUB.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"sub.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs], 
 				FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_MUL:
-			sprintf(CommandName,"MUL.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"mul.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs], 
 				FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_DIV:
-			sprintf(CommandName,"DIV.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"div.%s\t%s, %s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs], 
 				FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_SQRT:
-			sprintf(CommandName,"SQRT.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"sqrt.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_ABS:
-			sprintf(CommandName,"ABS.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"abs.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_MOV:
-			sprintf(CommandName,"MOV.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"mov.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_NEG:
-			sprintf(CommandName,"NEG.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"neg.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_ROUND_L:
-			sprintf(CommandName,"ROUND.L.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"round.l.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_TRUNC_L:
-			sprintf(CommandName,"TRUNC.L.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"trunc.l.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CEIL_L:
-			sprintf(CommandName,"CEIL.L.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"ceil.l.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_FLOOR_L:
-			sprintf(CommandName,"FLOOR.L.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"floor.l.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_ROUND_W:
-			sprintf(CommandName,"ROUND.W.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"round.w.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_TRUNC_W:
-			sprintf(CommandName,"TRUNC.W.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"trunc.w.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CEIL_W:
-			sprintf(CommandName,"CEIL.W.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"ceil.w.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_FLOOR_W:
-			sprintf(CommandName,"FLOOR.W.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"floor.w.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CVT_S:
-			sprintf(CommandName,"CVT.S.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"cvt.s.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CVT_D:
-			sprintf(CommandName,"CVT.D.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"cvt.d.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CVT_W:
-			sprintf(CommandName,"CVT.W.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"cvt.w.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_CVT_L:
-			sprintf(CommandName,"CVT.L.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"cvt.l.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fd], FPR_Name[command.FP.fs]);
 			break;
 		case R4300i_COP1_FUNCT_C_F:
-			sprintf(CommandName,"C.F.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.f.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_UN:
-			sprintf(CommandName,"C.UN.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.un.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_EQ:
-			sprintf(CommandName,"C.EQ.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.eq.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_UEQ:
-			sprintf(CommandName,"C.UEQ.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ueq.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_OLT:
-			sprintf(CommandName,"C.OLT.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.olt.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_ULT:
-			sprintf(CommandName,"C.ULT.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ult.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_OLE:
-			sprintf(CommandName,"C.OLE.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ole.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_ULE:
-			sprintf(CommandName,"C.ULE.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ule.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_SF:
-			sprintf(CommandName,"C.SF.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.sf.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_NGLE:
-			sprintf(CommandName,"C.NGLE.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ngle.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_SEQ:
-			sprintf(CommandName,"C.SEQ.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.seq.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_NGL:
-			sprintf(CommandName,"C.NGL.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ngl.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_LT:
-			sprintf(CommandName,"C.LT.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.lt.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_NGE:
-			sprintf(CommandName,"C.NGE.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.nge.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_LE:
-			sprintf(CommandName,"C.LE.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.le.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		case R4300i_COP1_FUNCT_C_NGT:
-			sprintf(CommandName,"C.NGT.%s\t%s, %s",FPR_Type(command.FP.fmt),  
+			sprintf(CommandName,"c.ngt.%s\t%s, %s",FPR_Type(command.FP.fmt),  
 				FPR_Name[command.FP.fs], FPR_Name[command.FP.ft]);
 			break;
 		default:

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -320,11 +320,13 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 		bkColorIndex = COLOR_WINDOW;
 	}
 
-	if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_BP) {
-		textColor = RGB(255, 0, 0);
-	}
-	if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_PC) {
+	int mask = R4300i_Status_PC | R4300i_Status_BP;
+	if ((r4300iCommandLine[ditem->itemID].status & mask) == mask) {
+		textColor = RGB(255, 128, 0);
+	} else if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_PC) {
 		textColor = RGB(0, 255, 0);
+	} else if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_BP) {
+		textColor = RGB(255, 0, 0);
 	}
 
 	oldColor = SetTextColor(ditem->hDC, textColor);

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -66,6 +66,10 @@ void Scroll_R4300i_Commands(int lines);
 
 LRESULT CALLBACK R4300i_Commands_Proc ( HWND, UINT, WPARAM, LPARAM );
 
+const COLORREF TEXT_COLOR_PC = RGB(0, 255, 0); // Currently executing instruction
+const COLORREF TEXT_COLOR_BP = RGB(255, 0, 0); // Breakpoint enabled
+const COLORREF TEXT_COLOR_PC_BP = RGB(255, 128, 0); // Currently executing instruction + breakpoint enabled
+
 static USHORT bCheckerBits[8] = { 0x33, 0x33, 0xcc, 0xcc, 0x33, 0x33, 0xcc, 0xcc }; // 2x2 checkerboard
 static HBITMAP hBmChecker;
 static HBRUSH hBrushChecker;
@@ -322,11 +326,11 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 
 	int mask = R4300i_Status_PC | R4300i_Status_BP;
 	if ((r4300iCommandLine[ditem->itemID].status & mask) == mask) {
-		textColor = RGB(255, 128, 0);
+		textColor = TEXT_COLOR_PC_BP;
 	} else if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_PC) {
-		textColor = RGB(0, 255, 0);
+		textColor = TEXT_COLOR_PC;
 	} else if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_BP) {
-		textColor = RGB(255, 0, 0);
+		textColor = TEXT_COLOR_BP;
 	}
 
 	oldColor = SetTextColor(ditem->hDC, textColor);

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -33,7 +33,7 @@
 
 char CommandName[100];
 
-#define R4300i_MaxCommandLines		30
+#define R4300i_MaxCommandLines		37
 
 typedef struct {
 	DWORD Location;
@@ -67,7 +67,7 @@ LRESULT CALLBACK R4300i_Commands_Proc ( HWND, UINT, WPARAM, LPARAM );
 static HWND R4300i_Commands_hDlg, hList, hAddress, hFunctionlist, hGoButton, hBreakButton,
 	hStepButton, hSkipButton, hBPButton, hR4300iRegisters, hRSPDebugger, hRSPRegisters,
 	hMemory, hScrlBar;
-static R4300ICOMMANDLINE r4300iCommandLine[30];
+static R4300ICOMMANDLINE r4300iCommandLine[R4300i_MaxCommandLines];
 BOOL InR4300iCommandsWindow = FALSE;
 
 void __cdecl Create_R4300i_Commands_Window ( int Child ) {
@@ -244,15 +244,15 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 	SetBkMode( ditem->hDC, TRANSPARENT );
 
 	if (strlen (Command) == 0 ) {
-		SetRect(&TextRect,ditem->rcItem.left,ditem->rcItem.top, ditem->rcItem.left + 83,
+		SetRect(&TextRect,ditem->rcItem.left,ditem->rcItem.top, ditem->rcItem.left + 104,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Offset,strlen(Offset), &TextRect,DT_SINGLELINE | DT_VCENTER);
 		
-		SetRect(&TextRect,ditem->rcItem.left + 83,ditem->rcItem.top, ditem->rcItem.left + 165,
+		SetRect(&TextRect,ditem->rcItem.left + 104,ditem->rcItem.top, ditem->rcItem.left + 190,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Instruction,strlen(Instruction), &TextRect,DT_SINGLELINE | DT_VCENTER);
 
-		SetRect(&TextRect,ditem->rcItem.left + 165,ditem->rcItem.top, ditem->rcItem.right,
+		SetRect(&TextRect,ditem->rcItem.left + 190,ditem->rcItem.top, ditem->rcItem.right,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Arguments,strlen(Arguments), &TextRect,DT_SINGLELINE | DT_VCENTER);
 	} else {
@@ -310,54 +310,54 @@ void Paint_R4300i_Commands (HWND hDlg) {
 	BeginPaint( hDlg, &ps );
 		
 	rcBox.left   = 5;   rcBox.top    = 5;
-	rcBox.right  = 343; rcBox.bottom = 463;
+	rcBox.right  = 413; rcBox.bottom = 563;
 	DrawEdge( ps.hdc, &rcBox, EDGE_RAISED, BF_RECT );
 		
 	rcBox.left   = 8;   rcBox.top    = 8;
-	rcBox.right  = 340; rcBox.bottom = 460;
+	rcBox.right  = 410; rcBox.bottom = 560;
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED, BF_RECT );
 		
-	rcBox.left   = 347; rcBox.top    = 7;
-	rcBox.right  = 446; rcBox.bottom = 42;
+	rcBox.left   = 417; rcBox.top    = 7;
+	rcBox.right  = 516; rcBox.bottom = 42;
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED, BF_RECT );
 		
-	rcBox.left   = 352; rcBox.top    = 2;
-	rcBox.right  = 400; rcBox.bottom = 15;
+	rcBox.left   = 422; rcBox.top    = 2;
+	rcBox.right  = 470; rcBox.bottom = 15;
 	FillRect( ps.hdc, &rcBox,(HBRUSH)COLOR_WINDOW);
 		
 	if (NoOfMapEntries) {
-		rcBox.left   = 347; rcBox.top    = 49;
-		rcBox.right  = 446; rcBox.bottom = 84;
+		rcBox.left   = 417; rcBox.top    = 49;
+		rcBox.right  = 516; rcBox.bottom = 84;
 		DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED, BF_RECT );
 		
-		rcBox.left   = 352; rcBox.top    = 44;
-		rcBox.right  = 390; rcBox.bottom = 57;
+		rcBox.left   = 422; rcBox.top    = 44;
+		rcBox.right  = 460; rcBox.bottom = 57;
 		FillRect( ps.hdc, &rcBox,(HBRUSH)COLOR_WINDOW);
 	}
 
 	rcBox.left   = 14; rcBox.top    = 14;
-	rcBox.right  = 88; rcBox.bottom = 32;
+	rcBox.right  = 112; rcBox.bottom = 32;
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED , BF_RECT );
 
-	rcBox.left   = 86; rcBox.top    = 14;
-	rcBox.right  = 173; rcBox.bottom = 32;
+	rcBox.left   = 110; rcBox.top    = 14;
+	rcBox.right  = 198; rcBox.bottom = 32;
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED , BF_RECT );
 
-	rcBox.left   = 171; rcBox.top    = 14;
-	rcBox.right  = 320; rcBox.bottom = 32;
+	rcBox.left   = 196; rcBox.top    = 14;
+	rcBox.right  = 390; rcBox.bottom = 32;
 	DrawEdge( ps.hdc, &rcBox, EDGE_ETCHED , BF_RECT );
 
 	hOldFont = (HFONT)SelectObject( ps.hdc,GetStockObject(DEFAULT_GUI_FONT ) );
 	OldBkMode = SetBkMode( ps.hdc, TRANSPARENT );
 		
 	TextOut( ps.hdc, 23,16,"Offset",6);
-	TextOut( ps.hdc, 97,16,"Instruction",11);
-	TextOut( ps.hdc, 180,16,"Arguments",9);
-	TextOut( ps.hdc, 354,2," Address ",9);
-	TextOut( ps.hdc, 354,19,"0x",2);
+	TextOut( ps.hdc, 119,16,"Instruction",11);
+	TextOut( ps.hdc, 205,16,"Arguments",9);
+	TextOut( ps.hdc, 424,2," Address ",9);
+	TextOut( ps.hdc, 424,19,"0x",2);
 	
 	if (NoOfMapEntries) {
-		TextOut( ps.hdc, 354,44," goto:",6);
+		TextOut( ps.hdc, 424,44," goto:",6);
 	}
 
 	SelectObject( ps.hdc,hOldFont );
@@ -445,11 +445,13 @@ LRESULT CALLBACK R4300i_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
 		if ((HWND)lParam == hScrlBar) {
 			DWORD location;
 			char Value[20];
+			DWORD page_size = (R4300i_MaxCommandLines - 1) * 4;
+			DWORD max_location = UINT_MAX - page_size + 1;
 
 			GetWindowText(hAddress,Value,sizeof(Value));
 			location = AsciiToHex(Value) & ~3;
 			
-			switch (LOWORD(wParam))  {			
+			switch (LOWORD(wParam)) {
 			case SB_LINEDOWN:
 				if (location < 0xFFFFFFFC) {
 					sprintf(Value,"%08X",location + 0x4);
@@ -468,18 +470,19 @@ LRESULT CALLBACK R4300i_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
 					SetWindowText(hAddress,Value);
 				}
 				break;
-			case SB_PAGEDOWN:				
-				if (location < 0xFFFFFF8C) {
-					sprintf(Value,"%08X",location + 0x74);
-					SetWindowText(hAddress,Value);
-				} else {
-					sprintf(Value,"%08X",0xFFFFFF8F);
-					SetWindowText(hAddress,Value);
+			case SB_PAGEDOWN:
+				if (location < max_location) {
+					sprintf(Value, "%08X", location + page_size);
+					SetWindowText(hAddress, Value);
 				}
-				break;			
+				else {
+					sprintf(Value, "%08X", max_location);
+					SetWindowText(hAddress, Value);
+				}
+				break;
 			case SB_PAGEUP:
-				if (location > 0x74 ) {
-					sprintf(Value,"%08X",location - 0x74);
+				if (location > (R4300i_MaxCommandLines - 1) * 4) {
+					sprintf(Value,"%08X",location - page_size);
 					SetWindowText(hAddress,Value);
 				} else {
 					sprintf(Value,"%08X",0);
@@ -496,97 +499,97 @@ LRESULT CALLBACK R4300i_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
 }
 
 void R4300i_Commands_Setup ( HWND hDlg ) {
-#define WindowWidth  480
-#define WindowHeight 520
+#define WindowWidth  550
+#define WindowHeight 620
 	DWORD X, Y;
 	
 	hList = CreateWindowEx(WS_EX_STATICEDGE, "LISTBOX","", WS_CHILD | WS_VISIBLE | 
-		LBS_OWNERDRAWFIXED | LBS_NOTIFY,14,30,303,445, hDlg, 
+		LBS_OWNERDRAWFIXED | LBS_NOTIFY,14,30,373,545, hDlg, 
 		(HMENU)IDC_LIST, hInst,NULL );
 	if ( hList) {
-		SendMessage(hList,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
+		SendMessage(hList,WM_SETFONT, (WPARAM)GetStockObject(ANSI_FIXED_FONT),0);
 		SendMessage(hList,LB_SETITEMHEIGHT, (WPARAM)0,(LPARAM)MAKELPARAM(14, 0));
 	}
 
 	hAddress = CreateWindowEx(0,"EDIT","", WS_CHILD | ES_UPPERCASE | WS_VISIBLE | 
-		WS_BORDER | WS_TABSTOP,372,17,65,18, hDlg,(HMENU)IDC_ADDRESS,hInst, NULL );
+		WS_BORDER | WS_TABSTOP,442,17,65,18, hDlg,(HMENU)IDC_ADDRESS,hInst, NULL );
 	if (hAddress) {
 		SendMessage(hAddress,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		SendMessage(hAddress,EM_SETLIMITTEXT, (WPARAM)8,(LPARAM)0);
 	} 
 
 	hFunctionlist = CreateWindowEx(0,"COMBOBOX","", WS_CHILD | WS_VSCROLL |
-		CBS_DROPDOWNLIST | CBS_SORT | WS_TABSTOP,352,56,89,150,hDlg,
+		CBS_DROPDOWNLIST | CBS_SORT | WS_TABSTOP,422,56,89,150,hDlg,
 		(HMENU)IDCfunctION_COMBO,hInst,NULL);		
 	if (hFunctionlist) {
 		SendMessage(hFunctionlist,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
 
 	hGoButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Go", WS_CHILD | 
-		BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, 347,56,100,24, hDlg,(HMENU)IDC_GO_BUTTON,
+		BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, 417,56,100,24, hDlg,(HMENU)IDC_GO_BUTTON,
 		hInst,NULL );
 	if (hGoButton) {
 		SendMessage(hGoButton,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
 	
 	hBreakButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Break", WS_DISABLED | 
-		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,85,100,24,hDlg,
+		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,85,100,24,hDlg,
 		(HMENU)IDC_BREAK_BUTTON,hInst,NULL );
 	if (hBreakButton) {
 		SendMessage(hBreakButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hStepButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Step", WS_CHILD | 
-		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,114,100,24,hDlg,
+		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,114,100,24,hDlg,
 		(HMENU)IDC_STEP_BUTTON,hInst,NULL );
 	if (hStepButton) {
 		SendMessage(hStepButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hSkipButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Skip", WS_CHILD | 
-		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,143,100,24,hDlg,
+		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,143,100,24,hDlg,
 		(HMENU)IDC_SKIP_BUTTON,hInst,NULL );
 	if (hSkipButton) {
 		SendMessage(hSkipButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hBPButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Break Points", WS_CHILD | 
-		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,324,100,24,hDlg,
+		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,424,100,24,hDlg,
 		(HMENU)IDC_BP_BUTTON,hInst,NULL );
 	if (hBPButton) {
 		SendMessage(hBPButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 		
 	hR4300iRegisters = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON","R4300i &Registers...",
-		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,353,100,24,hDlg,
+		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,453,100,24,hDlg,
 		(HMENU)IDC_R4300I_REGISTERS_BUTTON,hInst,NULL );
 	if (hR4300iRegisters) {
 		SendMessage(hR4300iRegisters,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hRSPDebugger = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "RSP &Debugger...", 
-		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,382,100,24,hDlg,
+		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,482,100,24,hDlg,
 		(HMENU)IDCrsP_DEBUGGER_BUTTON,hInst,NULL );
 	if (hRSPDebugger) {
 		SendMessage(hRSPDebugger,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hRSPRegisters = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "RSP R&egisters...",
-		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,411,100,24,hDlg,
+		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,511,100,24,hDlg,
 		(HMENU)IDCrsP_REGISTERS_BUTTON,hInst,NULL );
 	if (hRSPRegisters) {
 		SendMessage(hRSPRegisters,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
 
 	hMemory = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "&Memory...", WS_CHILD | 
-		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,440,100,24,hDlg,
+		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 417,540,100,24,hDlg,
 		(HMENU)IDC_MEMORY_BUTTON,hInst,NULL );
 	if (hMemory) {
 		SendMessage(hMemory,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 	
-	hScrlBar = CreateWindowEx(WS_EX_STATICEDGE, "SCROLLBAR","", WS_CHILD | WS_VISIBLE | 
-		WS_TABSTOP | SBS_VERT, 318,14,18,439, hDlg, (HMENU)IDC_SCRL_BAR, hInst, NULL );
+	hScrlBar = CreateWindowEx(0, "SCROLLBAR","", WS_CHILD | WS_VISIBLE | 
+		WS_TABSTOP | SBS_VERT, 388,14,18,539, hDlg, (HMENU)IDC_SCRL_BAR, hInst, NULL );
 
 	if ( RomFileSize != 0 ) {
 		Enable_R4300i_Commands_Window();
@@ -1287,7 +1290,7 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 }
 
 void RefreshR4300iCommands ( void ) {
-	DWORD location, LinesUsed;
+	DWORD location, max_location, LinesUsed = 1;
 	char AsciiAddress[20];
 	int count;
 
@@ -1296,7 +1299,8 @@ void RefreshR4300iCommands ( void ) {
 	GetWindowText(hAddress,AsciiAddress,sizeof(AsciiAddress));
 	location = AsciiToHex(AsciiAddress) & ~3;
 
-	if (location > 0xFFFFFF88) { location = 0xFFFFFF88; }
+	max_location = 0xFFFFFFFF - R4300i_MaxCommandLines * 4 + 1;
+	if (location > max_location) { location = max_location; }
 	for (count = 0 ; count < R4300i_MaxCommandLines; count += LinesUsed ){
 		LinesUsed = DisplayR4300iCommand ( location, count );
 		location += 4;
@@ -1338,7 +1342,7 @@ void SetR4300iCommandViewto ( UINT NewLocation ) {
 	GetWindowText(hAddress,Value,sizeof(Value));
 	location = AsciiToHex(Value) & ~3;
 
-	if ( NewLocation < location || NewLocation >= location + 120 ) {
+	if ( NewLocation < location || NewLocation >= location + R4300i_MaxCommandLines * 4 ) {
 		sprintf(Value,"%08X",NewLocation);
 		SetWindowText(hAddress,Value);
 	} else {
@@ -1351,18 +1355,18 @@ void Update_r4300iCommandList (void) {
 	
 	if (NoOfMapEntries == 0) {
 		ShowWindow(hFunctionlist, FALSE);
-		SetWindowPos(hGoButton,0,347,56,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hBreakButton,0,347,85,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hStepButton,0,347,114,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hSkipButton,0,347,143,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hGoButton,0,417,56,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hBreakButton,0,417,85,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hStepButton,0,417,114,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hSkipButton,0,417,143,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
 	} else {	
 		DWORD count, pos;
 
 		ShowWindow(hFunctionlist, TRUE);
-		SetWindowPos(hGoButton,0,347,86,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hBreakButton,0,347,115,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hStepButton,0,347,144,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
-		SetWindowPos(hSkipButton,0,347,173,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hGoButton,0,417,86,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hBreakButton,0,417,115,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hStepButton,0,417,144,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
+		SetWindowPos(hSkipButton,0,417,173,0,0, SWP_NOZORDER | SWP_NOSIZE| SWP_SHOWWINDOW);
 		
 		SendMessage(hFunctionlist,CB_RESETCONTENT,(WPARAM)0,(LPARAM)0);		
 		for (count = 0; count < NoOfMapEntries; count ++ ) {

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -323,6 +323,9 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 	if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_BP) {
 		textColor = RGB(255, 0, 0);
 	}
+	if (r4300iCommandLine[ditem->itemID].status & R4300i_Status_PC) {
+		textColor = RGB(0, 255, 0);
+	}
 
 	oldColor = SetTextColor(ditem->hDC, textColor);
 	oldBkColor = SetBkColor(ditem->hDC, GetSysColor(bkColorIndex));

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -249,13 +249,19 @@ void DrawR4300iCommand ( LPARAM lParam ) {
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Offset,strlen(Offset), &TextRect,DT_SINGLELINE | DT_VCENTER);
 		
-		SetRect(&TextRect,ditem->rcItem.left + 104,ditem->rcItem.top, ditem->rcItem.left + 190,
-			ditem->rcItem.bottom);	
-		DrawText(ditem->hDC,Instruction,strlen(Instruction), &TextRect,DT_SINGLELINE | DT_VCENTER);
+		if (strlen(Arguments) == 0) {
+			SetRect(&TextRect, ditem->rcItem.left + 104, ditem->rcItem.top, ditem->rcItem.right,
+				ditem->rcItem.bottom);
+			DrawText(ditem->hDC, Instruction, strlen(Instruction), &TextRect, DT_SINGLELINE | DT_VCENTER);
+		} else {
+			SetRect(&TextRect, ditem->rcItem.left + 104, ditem->rcItem.top, ditem->rcItem.left + 190,
+				ditem->rcItem.bottom);
+			DrawText(ditem->hDC, Instruction, strlen(Instruction), &TextRect, DT_SINGLELINE | DT_VCENTER);
 
-		SetRect(&TextRect,ditem->rcItem.left + 190,ditem->rcItem.top, ditem->rcItem.right,
-			ditem->rcItem.bottom);	
-		DrawText(ditem->hDC,Arguments,strlen(Arguments), &TextRect,DT_SINGLELINE | DT_VCENTER);
+			SetRect(&TextRect, ditem->rcItem.left + 190, ditem->rcItem.top, ditem->rcItem.right,
+				ditem->rcItem.bottom);
+			DrawText(ditem->hDC, Arguments, strlen(Arguments), &TextRect, DT_SINGLELINE | DT_VCENTER);
+		}
 	} else {
 		DrawText(ditem->hDC,Command,strlen(Command), &ditem->rcItem,DT_SINGLELINE | DT_VCENTER);
 	}

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -78,6 +78,7 @@ static HWND R4300i_Commands_hDlg, hList, hAddress, hFunctionlist, hGoButton, hBr
 	hMemory, hScrlBar;
 static R4300ICOMMANDLINE r4300iCommandLine[R4300i_MaxCommandLines];
 static int wheel = 0;
+static int thumb = -1;
 static UINT DragListMsg;
 static BOOL has_selection = FALSE;
 static DWORD selection_anchor = 0;
@@ -617,6 +618,17 @@ LRESULT CALLBACK R4300i_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
 					break;
 				case SB_PAGEDOWN:
 					Scroll_R4300i_Commands(page_size);
+					break;
+				case SB_THUMBTRACK: {
+					int position = HIWORD(wParam);
+					if (thumb >= 0) {
+						Scroll_R4300i_Commands(position - thumb);
+					}
+					thumb = position;
+					break;
+				}
+				case SB_ENDSCROLL:
+					thumb = -1;
 					break;
 				}
 			}

--- a/r4300i Memory.c
+++ b/r4300i Memory.c
@@ -71,6 +71,7 @@ static HANDLE hRefreshThread = NULL;
 static HANDLE hRefreshMutex = NULL;
 static int InMemoryWindow = FALSE;
 static int wheel = 0;
+static int thumb = -1;
 static struct MEMORY_VIEW_ROW MemoryViewRows[16];
 
 void __cdecl Create_Memory_Window ( int Child ) {
@@ -358,6 +359,17 @@ LRESULT CALLBACK Memory_Window_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM
 				break;
 			case SB_PAGEDOWN:
 				Scroll_Memory_View(16);
+				break;
+			case SB_THUMBTRACK: {
+				int position = HIWORD(wParam);
+				if (thumb >= 0) {
+					Scroll_Memory_View(position - thumb);
+				}
+				thumb = position;
+				break;
+			}
+			case SB_ENDSCROLL:
+				thumb = -1;
 				break;
 			}
 		}


### PR DESCRIPTION
Followup to #5, these improvements are to the r4300i Commands window. Primary changes:

- Added selection and CTRL+C to copy lines.
  - Supports selection ranges larger than the ListView; scroll and Shift+Click to select all text from the anchor to the click location (even across multiple pages).
  - Scroll-on-select would be nice to have, but it is not implemented here.
  - Keyboard selection would also be nice. Shift + arrows/page up/page down seems like it would be a decent UX... TBD.
  - Right click to copy + deselect. Or hold left click and press Esc or right click to deselect without copying.
- Added support for scrolling with the mouse wheel.
- Added support for scrolling with the keyboard when the ListView has focus.
- Added support for scrolling with the scrollbar thumb.
- Switched to a fixed-width font for better readability.
- Show opcodes (instruction bytes).
- Increased the window size to accommodate the better font and OpCode column.
- Normalized all instructions to lowercase.
- New colors to represent instruction state:
  - Red: Breakpoint
  - Green + outline: Current PC
  - Orange + outline: Current PC + breakpoint
  - Blue background: Selection highlight
- Fix watchpoint access size checks so they don't have to be an exact match on the address.
- Minor bug fixes.

Some additional things I would like to do before merging:

- [x] Show instruction opcodes (bytes)
- [x] Copy to clipboard
- [ ] ~Inline assembler~ (postponed)

Copying requires either selecting a range of lines or just always copy whatever is drawn to the screen. I would like to make it possible to select ranges larger than what can be shown in a single page. It's a bit of work.

The inline assembler would allow editing instructions. It could also make use of the line range selections.

![new-debugger](https://user-images.githubusercontent.com/456942/173150902-09a39cbc-096c-417f-b7a3-85ed3b592884.png)
