### PR TITLE
Fix manufacturer decoding in ROM info

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -1826,6 +1826,7 @@ LRESULT CALLBACK RomInfoProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			SetDlgItemText(hDlg, IDC_INFO_CARTID, String);
 
 			switch (RomHeader[0x38]) {
+				case 'C':
 				case 'N':
 					SetDlgItemText(hDlg, IDC_INFO_MANUFACTURER, " Nintendo");
 					break;

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -684,6 +684,7 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 			break;
 		case RB_Manufacturer:
 			switch (pRomInfo->Manufacturer) {
+				case 'C':
 				case 'N':
 					strncpy(lpdi->item.pszText, "Nintendo", lpdi->item.cchTextMax);
 					break;


### PR DESCRIPTION
- Fixes info for Ocarina of Time.
- Matches the decoding by uCON64.