### PR TITLE
Draw word separators in the memory viewer

### DIFF
--- a/r4300i Memory.c
+++ b/r4300i Memory.c
@@ -320,7 +320,19 @@ LRESULT CALLBACK Memory_Window_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM
 					lplvcd->clrText = TC_DEFAULT;
 					lplvcd->clrTextBk = BG_DEFAULT;
 				}
-				SetWindowLong(hDlg, DWL_MSGRESULT, CDRF_NEWFONT);
+				SetWindowLong(hDlg, DWL_MSGRESULT, CDRF_NEWFONT | CDRF_NOTIFYPOSTPAINT);
+				return TRUE;
+			case CDDS_ITEMPOSTPAINT | CDDS_SUBITEM:
+				if (lplvcd->iSubItem >= 1 && lplvcd->iSubItem < 13 && (lplvcd->iSubItem - 1) % 4 == 3) {
+					int x = (lplvcd->iSubItem - 1) * 28 + 117;
+					int y = lplvcd->nmcd.dwItemSpec * 17 + 24;
+
+					rcBox.left = x;
+					rcBox.top = y;
+					rcBox.right = x + 1;
+					rcBox.bottom = y + 17;
+					FillRect(lplvcd->nmcd.hdc, &rcBox, (HBRUSH)GetStockObject(GRAY_BRUSH));
+				}
 				return TRUE;
 			default:
 				SetWindowLong(hDlg, DWL_MSGRESULT, CDRF_DODEFAULT);


### PR DESCRIPTION
Improves clarity of byte positioning at a glance. This draws dark vertical bars between columns 3,4, 7,8, and B,C.

![memview-separators](https://user-images.githubusercontent.com/456942/172025484-4791008c-794d-4943-ac79-782af83e4d15.png)