### PR TITLE
Fix sorting in ROM browser

### DIFF
--- a/Language.h
+++ b/Language.h
@@ -167,18 +167,18 @@ char * GS               ( int StringID );
 #define RB_NOTES_PLUGIN			306
 #define RB_NOTES_USER			307
 #define RB_CART_ID				308
-#define RB_MANUFACTUER			309
-#define RB_COUNTRY				310
-#define RB_DEVELOPER			311
-#define RB_CRC1					312
-#define RB_CRC2					313
-#define RB_CICCHIP				314
-#define RB_RELEASE_DATE			315
-#define RB_GENRE				316
-#define RB_PLAYERS				317
-#define RB_FORCE_FEEDBACK		318
-#define RB_RELEASE_VER			319
-#define RB_SDK_VER				320
+#define RB_RELEASE_VER			309
+#define RB_SDK_VER				310
+#define RB_MANUFACTUER			311
+#define RB_COUNTRY				312
+#define RB_DEVELOPER			313
+#define RB_CRC1					314
+#define RB_CRC2					315
+#define RB_CICCHIP				316
+#define RB_RELEASE_DATE			317
+#define RB_GENRE				318
+#define RB_PLAYERS				319
+#define RB_FORCE_FEEDBACK		320
 
 //Select Rom
 #define SELECT_ROM_DIR			321

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -55,18 +55,18 @@
 #define RB_PluginNotes		6
 #define RB_UserNotes		7
 #define RB_CartridgeID		8
-#define RB_Manufacturer		9
-#define RB_Country			10
-#define RB_Developer		11
-#define RB_Crc1				12
-#define RB_Crc2				13
-#define RB_CICChip			14
-#define RB_ReleaseDate		15
-#define RB_Genre			16
-#define RB_Players			17
-#define RB_ForceFeedback	18
-#define RB_ReleaseVer		19
-#define RB_SdkVer			20
+#define RB_ReleaseVer		9
+#define RB_SdkVer			10
+#define RB_Manufacturer		11
+#define RB_Country			12
+#define RB_Developer		13
+#define RB_Crc1				14
+#define RB_Crc2				15
+#define RB_CICChip			16
+#define RB_ReleaseDate		17
+#define RB_Genre			18
+#define RB_Players			19
+#define RB_ForceFeedback	20
 #define COLOR_TEXT			0
 #define COLOR_SELECTED_TEXT	1
 #define COLOR_HIGHLIGHTED   2
@@ -546,8 +546,10 @@ void RomList_ColumnSortList(LPNMLISTVIEW pnmv) {
 
 		for (count = NoOfSortKeys - 1; count > 0; count--) {
 			GetSortField(count - 1, String, sizeof(String));
-			SetSortField(String, count);
-			SetSortAscending(IsSortAscending(count - 1), count);
+			if (strlen(String) > 0) {
+				SetSortField(String, count);
+				SetSortAscending(IsSortAscending(count - 1), count);
+			}
 		}
 		SetSortField(RomBrowserFields[index].Name, 0);
 		SetSortAscending(TRUE, 0);
@@ -618,11 +620,21 @@ bool RomList_Compare(const ROM_INFO& a, const ROM_INFO& b) {
 				compare = lstrcmpi(pRomInfo1.Developer, pRomInfo2.Developer);
 				break;
 			case RB_Crc1:
-				compare = (int)pRomInfo1.CRC1 - (int)pRomInfo2.CRC1;
+			{
+				char crc_str1[9], crc_str2[9];
+				sprintf(crc_str1, "%08x", pRomInfo1.CRC1);
+				sprintf(crc_str2, "%08x", pRomInfo2.CRC1);
+				compare = lstrcmpi(crc_str1, crc_str2);
 				break;
+			}
 			case RB_Crc2:
-				compare = (int)pRomInfo1.CRC2 - (int)pRomInfo2.CRC2;
+			{
+				char crc_str1[9], crc_str2[9];
+				sprintf(crc_str1, "%08x", pRomInfo1.CRC2);
+				sprintf(crc_str2, "%08x", pRomInfo2.CRC2);
+				compare = lstrcmpi(crc_str1, crc_str2);
 				break;
+			}
 			case RB_CICChip:
 			{
 				char junk1[50], junk2[50];
@@ -648,16 +660,15 @@ bool RomList_Compare(const ROM_INFO& a, const ROM_INFO& b) {
 				break;
 		}
 
-		switch (compare) {
-			case 1:
-				// a > b (compare is returning 1, so a is greater than b)
-				return false;
-			case 0:
-				// Same, continue the compare by using the other sort keys
-				break;
-			default:
-				// a < b (compare is returning -1, so a is less than b)
-				return true;
+		if (compare > 0) {
+			// a > b (compare is returning 1, so a is greater than b)
+			return false;
+		} else if (compare == 0) {
+			// Same, continue the compare by using the other sort keys
+			break;
+		} else {
+			// a < b (compare is returning -1, so a is less than b)
+			return true;
 		}
 	}
 	return false;
@@ -700,7 +711,7 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 			sprintf(lpdi->item.pszText, "v1.%d", pRomInfo->ReleaseVersion);
 			break;
 		case RB_SdkVer:
-			sprintf(lpdi->item.pszText, "v%d.%d%c", pRomInfo->SdkVersion[0] / 10, pRomInfo->SdkVersion[0] % 10, pRomInfo->SdkVersion[1]);
+			sprintf(lpdi->item.pszText, "v%d.%d%c", pRomInfo->SdkVersion[1] / 10, pRomInfo->SdkVersion[1] % 10, pRomInfo->SdkVersion[0]);
 			break;
 		case RB_Manufacturer:
 			switch (pRomInfo->Manufacturer) {

--- a/RomTools_Common.cpp
+++ b/RomTools_Common.cpp
@@ -156,8 +156,8 @@ void GetRomReleaseVersion(int* ReleaseVersion, BYTE* RomData) {
 }
 
 void GetRomSdkVersion(BYTE* SdkVersion, BYTE* RomData) {
-	SdkVersion[0] = RomData[0x0D];
-	SdkVersion[1] = RomData[0x0C];
+	SdkVersion[0] = RomData[0x0C];
+	SdkVersion[1] = RomData[0x0D];
 }
 
 void GetRomManufacturer(BYTE* Manufacturer, BYTE* RomData) {


### PR DESCRIPTION
- The comparison function was wrong. It only returned false if the
  difference between the items was exactly 1! Caused assertion errors in
  std::sort() with some sort field selections.
- CRC comparisons were broken (signed/unsigned comparisons).
- Comparison indices were broken by adding the release version and SDK
  version fields in the wrong place.