### PR TITLE
Fix crash in cheat search

### DIFF
--- a/CheatSearch.c
+++ b/CheatSearch.c
@@ -757,12 +757,12 @@ void Search(HWND hDlg) {
 
 		// Search performed using previous (or the initial) search result list
 		else {
-			struct CS_RESULTS tmp;
+			struct CS_RESULTS tmp = { 0 };
 			WORD mem_value;
 			CS_HITS* hit;
 			BOOL matched;
 
-			CS_InitResults(&tmp);
+			CS_ReserveSpace(&tmp, dwendAddress - dwstartAddress);
 
 			// Subsequent searches of Hex/Dec values
 			for (count = 0; count < results.num_stored; count++) {


### PR DESCRIPTION
- When continuing an "unknown value" search with 8-bit values in 8 MB of
  RAM, `realloc` will be called thousands of times and will eventually
  fail on Windows. The failed allocation is basically ignored and
  invalid memory will be accessed.
- This patch fixes the issue by preallocating the entire memory size
  when continuing a search.