### PR TITLE
Enabled Remember selected cheats by default

### DIFF
--- a/Main.h
+++ b/Main.h
@@ -65,7 +65,7 @@ extern "C" {
 #define Default_LimitFPS			TRUE
 #define Default_AlwaysOnTop			FALSE
 #define Default_BasicMode			TRUE
-#define Default_RememberCheats		FALSE
+#define Default_RememberCheats		TRUE  // Changed this to on by default as it makes more sense than having to keep enabling if not checked (Gent)
 #define Default_RomsToRemember		4
 #define Default_RomsDirsToRemember	4
 #define LinkBlocks


### PR DESCRIPTION
Changed Remember selected cheats to be enabled as default.This makes far more sense than having to keep re-enabling everytime the emulator is closed.
