### PR TITLE
Fix many bugs in cheat search

### DIFF
--- a/CheatSearch_Search.c
+++ b/CheatSearch_Search.c
@@ -10,72 +10,167 @@ void CS_InitSearch(CS_SEARCH* search) {
 	strcpy(search->search_string, "");
 }
 
-// This does not clear allocated memory, be sure to call CS_ClearResults instead
-void CS_InitResults(CS_RESULTS* res) {
-	res->allocated = 0;
-	res->num_stored = 0;
-	res->hits = NULL;
-}
-
 // This is helpful for the initial search, it can preallocate enough memory to hold all unknown search results (4 or 8 million depending on RDRAM setting)
-void CS_ReserveSpace(CS_RESULTS* res, DWORD amount) {
-	CS_HITS* tmp;
+BOOL CS_ReserveSpace(CS_RESULTS* res, DWORD amount) {
+	BYTE* tmp;
 
 	CS_ClearResults(res);
 
-	tmp = malloc(sizeof(*res->hits) * amount);
-	if (tmp == NULL)
-		return;
-	res->hits = tmp;
+	tmp = calloc(amount / 8, 1);
+	if (tmp == NULL) {
+		return FALSE;
+	}
+	res->hits.bitmap = tmp;
 
-	res->allocated = amount;
+	tmp = malloc(amount);
+	if (tmp == NULL) {
+		free(res->hits.bitmap);
+		return FALSE;
+	}
+	res->hits.values = tmp;
+
+	tmp = malloc(amount);
+	if (tmp == NULL) {
+		free(res->hits.bitmap);
+		free(res->hits.values);
+		return FALSE;
+	}
+	res->hits.prev_values = tmp;
+
+	res->hits.reserved = amount;
+
+	return TRUE;
 }
 
-void CS_AddResult(CS_RESULTS* res, DWORD address, WORD value) {
-	CS_HITS* tmp;
-
-	// Reallocate memory if needed
-	if (res->allocated == res->num_stored) {
-		tmp = (CS_HITS*)realloc(res->hits, sizeof(*res->hits) * (res->allocated + arr_growth));
-
-		// Failure to allocate more memory
-		// Consider throwing an error here of some kind
-		if (tmp == NULL) {
-			CS_ClearResults(res);
-			return;
-		}
-
-		res->hits = tmp;
-		res->allocated += arr_growth;
+void CS_ClearResults(CS_RESULTS* res) {
+	if (res->hits.bitmap != NULL) {
+		free(res->hits.bitmap);
+	}
+	if (res->hits.values != NULL) {
+		free(res->hits.values);
+	}
+	if (res->hits.prev_values != NULL) {
+		free(res->hits.prev_values);
+	}
+	if (res->addresses != NULL) {
+		free(res->addresses);
 	}
 
-	// Store the hit in the array
-	res->hits[res->num_stored].address = address;
-	res->hits[res->num_stored].value = value;
-	res->num_stored++;
+	res->hits.bitmap = NULL;
+	res->hits.values = NULL;
+	res->hits.prev_values = NULL;
+	res->addresses = NULL;
+	res->hits.reserved = 0;
+	res->allocated = 0;
+	res->num_stored = 0;
+}
+
+BOOL CS_ReallocateAddresses(CS_RESULTS *res) {
+	BYTE* tmp = (BYTE*)realloc(res->addresses, sizeof(DWORD) * (res->allocated + arr_growth));
+
+	// Failure to allocate more memory
+	if (tmp == NULL) {
+		CS_ClearResults(res);
+		return FALSE;
+	}
+
+	res->addresses = tmp;
+	res->allocated += arr_growth;
+
+	return TRUE;
+}
+
+BOOL CS_AddResultByte(CS_RESULTS* res, DWORD address, BYTE value) {
+	// Reallocate memory if needed
+	if (res->allocated == res->num_stored && !CS_ReallocateAddresses(res)) {
+		return FALSE;
+	}
+
+	// Store the hit in the bitmap
+	int index = address / 8;
+	int bit = address % 8;
+	res->hits.bitmap[index] |= (BYTE)(1 << bit);
+	res->hits.values[address] = value;
+	res->addresses[res->num_stored] = address;
+	res->num_stored += 1;
+
+	return TRUE;
+}
+
+BOOL CS_AddResultWord(CS_RESULTS* res, DWORD address, WORD value) {
+	// Reallocate memory if needed
+	if (res->allocated == res->num_stored && !CS_ReallocateAddresses(res)) {
+		return FALSE;
+	}
+
+	// Store the hit in the bitmap
+	int index = address / 8;
+	int bit = address % 8;
+	res->hits.bitmap[index] |= (BYTE)(3 << bit);
+	res->hits.values[address] = (BYTE)(value >> 8);
+	res->hits.values[address + 1] = (BYTE)(value);
+	res->addresses[res->num_stored] = address;
+	res->num_stored += 1;
+
+	return TRUE;
 }
 
 // TO DO!!
 // Come up with a better way to handle this
 void CS_AddTextResult(CS_RESULTS* res, DWORD address, char* value) {
-	CS_AddResult(res, address, 0);
+	CS_AddResultByte(res, address, 0);
 }
 
-void CS_ClearResults(CS_RESULTS* res) {
-	if (res->hits != NULL)
-		free(res->hits);
+BOOL CS_AddHitByte(CS_RESULTS* res, CS_HIT* hit) {
+	if (CS_AddResultByte(res, hit->address, (BYTE)hit->value)) {
+		res->hits.prev_values[hit->address] = (BYTE)hit->prev_value;
+		return TRUE;
+	}
 
-	CS_InitResults(res);
+	return FALSE;
 }
 
-void CS_AddHit(CS_RESULTS* res, CS_HITS* hit) {
-	CS_AddResult(res, hit->address, hit->value);
-	res->hits[res->num_stored - 1].prev_value = hit->prev_value;
+BOOL CS_AddHitWord(CS_RESULTS* res, CS_HIT* hit) {
+	if (!(hit->address & 1) && CS_AddResultWord(res, hit->address, hit->value)) {
+		res->hits.prev_values[hit->address] = (BYTE)(hit->prev_value >> 8);
+		res->hits.prev_values[hit->address + 1] = (BYTE)(hit->prev_value);
+		return TRUE;
+	}
+
+	return FALSE;
 }
 
-CS_HITS* CS_GetHit(CS_RESULTS* res, DWORD loc) {
-	if (loc < res->num_stored)
-		return &res->hits[loc];
-	else
-		return NULL;
+BOOL CS_HasHit(CS_RESULTS* res, DWORD address) {
+	if (address >= res->hits.reserved) {
+		return FALSE;
+	}
+
+	int index = address / 8;
+	int bit = address % 8;
+
+	return (res->hits.bitmap[index] & (BYTE)(1 << bit)) != 0;
+}
+
+BOOL CS_GetHitByte(CS_HIT* hit, CS_RESULTS* res, DWORD address) {
+	if (CS_HasHit(res, address)) {
+		hit->address = address;
+		hit->value = res->hits.values[address];
+		hit->prev_value = res->hits.prev_values[address];
+
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+BOOL CS_GetHitWord(CS_HIT* hit, CS_RESULTS* res, DWORD address) {
+	if (!(address & 1) && CS_HasHit(res, address)) {
+		hit->address = address;
+		hit->value = (res->hits.values[address] << 8) | res->hits.values[address + 1];
+		hit->prev_value = (res->hits.prev_values[address] << 8) | res->hits.prev_values[address + 1];
+
+		return TRUE;
+	}
+
+	return FALSE;
 }

--- a/CheatSearch_Search.h
+++ b/CheatSearch_Search.h
@@ -34,27 +34,40 @@ typedef struct CS_SEARCH {
 	NUMBITS searchNumBits;
 } CS_SEARCH;
 
-typedef struct CS_HITS {
+typedef struct CS_HIT {
 	DWORD address;		// The address the value was scanned at
 	WORD value;			// The value at the time of scan (These may not be the same, depending on the type of scan)
 	WORD prev_value;	// The previous value held at the address (Again, this may not be a static value... greater/less than scans)
-} CS_HITS;
+} CS_HIT;
+
+typedef struct CS_BITMAP {
+	BYTE* bitmap;		// A bitmap of addresses containing results
+	BYTE* values;		// An array of values at each address
+	BYTE* prev_values;	// An array of previous values at each address
+	DWORD reserved;		// Number of addresses that this bitmap can store
+} CS_BITMAP;
 
 // The search results
 typedef struct CS_RESULTS {
-	CS_HITS* hits;			// The stored results of the scan
-	DWORD allocated;		// The amount of memory allocated to results array
-	DWORD num_stored;		// The amount of search resutls stored in the results array
+	CS_BITMAP hits;		// The stored results of the scan
+	DWORD *addresses;	// THe list of addresses found; needed only for populating the listbox
+	DWORD allocated;	// The amount of memory allocated to addresses array
+	DWORD num_stored;	// The amount of search results stored in the addresses array
 } CS_RESULTS;
 
-
 void CS_InitSearch(CS_SEARCH* search);
-void CS_InitResults(CS_RESULTS* res);
-void CS_ReserveSpace(CS_RESULTS* res, DWORD amount);
-void CS_AddResult(CS_RESULTS* res, DWORD address, WORD value);
-void CS_AddTextResult(CS_RESULTS* res, DWORD address, char* value);
+
+BOOL CS_ReserveSpace(CS_RESULTS* res, DWORD amount);
 void CS_ClearResults(CS_RESULTS* res);
-void CS_AddHit(CS_RESULTS* res, CS_HITS* hit);
-CS_HITS* CS_GetHit(CS_RESULTS* res, DWORD loc);
+
+void CS_AddTextResult(CS_RESULTS* res, DWORD address, char *value);
+
+BOOL CS_AddResultByte(CS_RESULTS* res, DWORD address, BYTE value);
+BOOL CS_AddHitByte(CS_RESULTS* res, CS_HIT* hit);
+BOOL CS_GetHitByte(CS_HIT* hit, CS_RESULTS* res, DWORD address);
+
+BOOL CS_AddResultWord(CS_RESULTS* res, DWORD address, WORD value);
+BOOL CS_AddHitWord(CS_RESULTS* res, CS_HIT* hit);
+BOOL CS_GetHitByte(CS_HIT* hit, CS_RESULTS* res, DWORD address);
 
 #endif


### PR DESCRIPTION
- Memory allocation failures were causing cheat searches to miss millions of potential results. The cause was `realloc()` failures in `CS_AddResult()`. Allocations fail for very large blocks due to memory fragmentation. This is a 32-bit process, so it only has access to a 2 GB address space, and most of that is used for emulation, thread stacks, and a billion small allocations. The cheat search needs to allocate two 64 MB blocks (max) but the free space in the heap may not have two blocks large enough to satisfy it. When this happens, the current cheat results are thrown away and a new, smaller allocation replaces it. But the cheat search doesn't abort, it just continues on oblivious to the data loss.

- Allocation failures were resolved by reducing the total memory required. The new result layout needs only: two 8 MB blocks, one 1 MB block, and a growable block (64 KB to 32 MB) for the address list. In the worst case, memory use is still almost half as small as it was before. And because it's split into multiple blocks, there is a better chance that they will all fit into the fragmented heap.

- Better error handling when the dynamic block reallocation fails. I won't say it's perfect, since it can still have some leaks and bad user experience. But it's a start toward handling allocation failures gracefully.

- Removed `CS_InitResults()`. This was an internal function, users are not supposed to need to even know about it. Now it's inlined with `CS_ReserveSpace()` which is required to be called before using most of the `CS_` functions. (Except `CS_InitSearch()` which has nothing to do with the `CS_RESULTS` struct.)

- Interacting with `CS_RESULTS` and `CS_HITS` has been completely refactored. `CS_HITS` has been split into multiple memory blocks as described above. The "growable address list" has been moved to `CS_RESULTS`, and `CS_BITMAP` replaces the rest of `CS_HITS`. The new `CS_HIT` is a single-element view of the old `CS_HITS` to avoid changing user code too much.

- `CS_AddResult`, `CS_AddHit`, and `CS_GetHit` now all have two variants: one for bytes (8-bit searches) and one for words (16-bit searches). They each return BOOL, indicating errors when FALSE. And `CS_GetHit(Byte|Word)` takes an out-param as its first argument.

- Fixed some memory leaks in `WriteProject64ChtDev()`: `ChtDev->LastSearch->Results` was never freed. Also free memory in early returns.

- Fixed cheat search LiveUpdate thread so it won't deadlock when the emulator window/ROM browser is closed.

- Fixed the prefix find in the results listbox. With the listbox focuses, pressing any hex character on the keyboard will initiate a find. The old algorithm attempted to do prefix matching, but only did masked matches. So most of the time the find function didn't work at all. The new way is much shorter and actually works.

- Added braces on a lot of conditions to avoid goto-fail scenarios.

See also #19, which was caused by the same heap fragmentation issue. That PR only fixed one particular case.

----

TBD: Storing the list of addresses is still very wasteful. The list is necessary for `O(1)` time lookups when interacting with the result listbox. The listbox APIs use item indices for most operations, and the results listbox only contains addresses with "hits" in the cheat search. The naive solution is storing all addresses (32-bits each) in an array (max memory requirement is a 32 MB allocation block). This is the data structure used in both the original code and in this PR.

It is possible to reduce the memory requirement without degrading the lookup time terribly. First, observe that the address list is always sorted. Addresses are arranged in ascending order. Second, note that this sorted list contains a lot of redundancy; In the worst case with a fully populated list of 8-bit addresses, the first 65,536 addresses all share the same upper half; `0x0000`. The next 65,536 addresses also share the same upper half; `0x0001`. This pattern repeats to the end of the list, with upper half = `0x007f`.

Remove this redundancy by storing multiple arrays, let's call them "buckets", of 16-bit values (i.e., only storing the lower half of each address). Each bucket will have exactly 65,536 entries, working out to 128 KB for each. And we only need 128 _total_ buckets for a maximum of 16 MB required. That's a 50% reduction in the worst case. And even better, these smaller 128 KB blocks will be easier to allocate within the fragmented address space!

If it isn't clear by now, the index within the 128 buckets tells you the upper half of the address. Combine it with the lower half that is actually stored in the bucket, and you can recover the full address with half of the memory needed.

Lookups (find the Nth address in the list) can be made `O(log(n))` with a prefix sum tree over the 128 buckets. Constant time (`O(1)`) lookups are not possible because each bucket is dynamically sized (even if its allocation is fixed, though they can be made much smaller). The bucket only stores addresses with search hits. The naive search solution is linear (`O(n)`), requiring visiting each bucket to count how many addresses it contains; in the worst case, it visits all 128 buckets.

The prefix sum tree instead sums the bucket counts in a tree that can be binary searched. For 128 buckets, the log-time search reduces to 7 bucket visits.

One example prefix sum tree data structure that can be used is called a [Fenwick tree](https://en.wikipedia.org/wiki/Fenwick_tree). Storage requirements for it are only the 128 `int`s making up the partial sums for the bucket item counts plus an extra `int` for the total sum.

The only downside to this approach is the additional code complexity. There isn't a lot of code to write, but it is easy to mess it up if you don't know why the data structure is needed (or how it works). It's only marginally slower than the naive constant-time array lookups. More than fast enough for the listbox drawing and find operations.

The upsides are: About half of the memory requirement in the worst case (unknown 8-bit search across the full 8 MB N64 RAM). Much smaller allocations are needed, which is easier for a fragmented heap to satisfy.

I am not planning to implement the prefix sum tree in this PR. But I've decided to write my thoughts here just in case the 32 MB allocations in the cheat search ever become problematic. We'll have something to look back on as a proposed solution.