### PR TITLE
Remove half-baked XML chtdev file

### DIFF
--- a/CheatSearch_Dev.c
+++ b/CheatSearch_Dev.c
@@ -34,8 +34,8 @@ void CS_AddCode(CS_DEV *dev, CODEENTRY code) {
 
 // This is not a real deletion but simply a swap of pointers
 // The item that was removed will be at the end of the list, ready to be replaced/updated
-void CS_RemoveCodeAt(CS_DEV *dev, DWORD location) {
-	DWORD count;
+void CS_RemoveCodeAt(CS_DEV *dev, int location) {
+	int count;
 	
 	// Cannot swap if there are less than 2 items
 	if ((dev->num_stored - location) >= 2) {
@@ -47,7 +47,7 @@ void CS_RemoveCodeAt(CS_DEV *dev, DWORD location) {
 	dev->num_stored--;
 }
 
-CODEENTRY* CS_GetCodeAt(CS_DEV *dev, DWORD location) {
+CODEENTRY* CS_GetCodeAt(CS_DEV *dev, int location) {
 
 	// Check if the location is in bounds
 	if (dev->num_stored == 0 || location < 0 || location > dev->num_stored - 1)
@@ -63,7 +63,7 @@ void CS_ClearDev(CS_DEV *dev) {
 	CS_InitDev(dev);
 }
 
-void CS_SwapDev(CS_DEV *dev, DWORD loc1, DWORD loc2) {
+void CS_SwapDev(CS_DEV *dev, int loc1, int loc2) {
 	CODEENTRY *one, *two;
 	CODEENTRY hold;
 

--- a/CheatSearch_Dev.h
+++ b/CheatSearch_Dev.h
@@ -27,15 +27,6 @@ typedef struct LASTSEARCH {
 	char *Results;
 } LASTSEARCH;
 
-// For use in entering the found code into the cheat database
-// May be dumped later, most of this code is found elsewhere
-typedef struct CHTDEVENTRY {
-	char *Identifier;
-	char *Name;
-	LASTSEARCH *LastSearch;
-	CODEENTRY *Codes;
-} CHTDEVENTRY;
-
 // Grouping of all dev entry variables
 // Must be deallocated by calling CS_ClearDev
 typedef struct CS_DEV {
@@ -47,9 +38,9 @@ typedef struct CS_DEV {
 
 void CS_InitDev(CS_DEV *dev);
 void CS_AddCode(CS_DEV *dev, CODEENTRY code);
-void CS_RemoveCodeAt(CS_DEV *dev, DWORD location);
-CODEENTRY* CS_GetCodeAt(CS_DEV *dev, DWORD location);
+void CS_RemoveCodeAt(CS_DEV *dev, int location);
+CODEENTRY* CS_GetCodeAt(CS_DEV *dev, int location);
 void CS_ClearDev(CS_DEV *dev);
-void CS_SwapDev(CS_DEV *dev, DWORD loc1, DWORD loc2);
+void CS_SwapDev(CS_DEV *dev, int loc1, int loc2);
 
 #endif

--- a/CheatSearch_Search.c
+++ b/CheatSearch_Search.c
@@ -66,7 +66,7 @@ void CS_ClearResults(CS_RESULTS* res) {
 }
 
 BOOL CS_ReallocateAddresses(CS_RESULTS *res) {
-	BYTE* tmp = (BYTE*)realloc(res->addresses, sizeof(DWORD) * (res->allocated + arr_growth));
+	DWORD* tmp = (DWORD*)realloc(res->addresses, sizeof(DWORD) * (res->allocated + arr_growth));
 
 	// Failure to allocate more memory
 	if (tmp == NULL) {
@@ -118,6 +118,8 @@ BOOL CS_AddResultWord(CS_RESULTS* res, DWORD address, WORD value) {
 // TO DO!!
 // Come up with a better way to handle this
 void CS_AddTextResult(CS_RESULTS* res, DWORD address, char* value) {
+	(void)value;
+
 	CS_AddResultByte(res, address, 0);
 }
 

--- a/CheatSearch_Search.h
+++ b/CheatSearch_Search.h
@@ -68,6 +68,6 @@ BOOL CS_GetHitByte(CS_HIT* hit, CS_RESULTS* res, DWORD address);
 
 BOOL CS_AddResultWord(CS_RESULTS* res, DWORD address, WORD value);
 BOOL CS_AddHitWord(CS_RESULTS* res, CS_HIT* hit);
-BOOL CS_GetHitByte(CS_HIT* hit, CS_RESULTS* res, DWORD address);
+BOOL CS_GetHitWord(CS_HIT* hit, CS_RESULTS* res, DWORD address);
 
 #endif


### PR DESCRIPTION
No idea what the purpose of this is. Looks like some half-baked idea that never went anywhere.

- `ReadProject64ChtDev()` was never called. The function can read the contents of the XML file as a string, but it does not parse the XML. There is also no XML parser in the source tree. The function always returns NULL.

- `WriteProject64ChtDev()` was only called for known-value searches.

- The writer contained a bunch of memory leaks, so removing this code is better for everyone. I tried to fix these in #41, but also broke the calls to `CS_GetHit(Byte|Word)` in `ResultsToString()`. Oh well.

In addition to removing the XML stuff, I also fixed some warnings that have slowly cropped up. Some of these warnings were introduced recently in #41.

----

According to Gent, this was created as a workaround for flaky crashes in the cheat search. It provided at least something to look at for disaster recovery. We're now going to focus on improving stability instead of these workarounds. But in the near future, I also want to start working on a more proper "session persistence" for some of these things.

I was always annoyed by losing my debugger sessions when closing a ROM. And it's going to get worse when I start adding basic navigation "bookmarks" to the debugger and memory editor. I want to persist this info across sessions. But I want to do it without Ad Hoc XML writers, and I don't want to bring in an XML parser anyway. That's ridiculous.