### PR TITLE
Remove Hidden Window and improve stability when resetting

### DIFF
--- a/Cpu.c
+++ b/Cpu.c
@@ -173,7 +173,12 @@ void CloseCpu (void) {
 
 	if (hCPU != NULL) { 
 		DisplayError("Emulation thread failed to terminate plugins\nReport this if you can reproduce reliably");
+
+		// This is a last resort when the audio thread refuses to gracefully exit.
+		// Calling this function WILL cause problems!
+		// SEE: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminatethread#remarks
 		TerminateThread(hCPU, 0);
+
 		hCPU = NULL;
 		SetupPlugins(hMainWindow,FALSE);
 	}
@@ -455,10 +460,6 @@ void ProcessMessages (void) {
 
 void DoSomething ( void ) {
 	if (CPU_Action.CloseCPU) { 
-		if (GfxRomClosed != NULL)
-			GfxRomClosed();
-		if (ContRomClosed != NULL)
-			ContRomClosed();
 		CoUninitialize();
 		ExitThread(0); 
 	}

--- a/Cpu.c
+++ b/Cpu.c
@@ -180,7 +180,6 @@ void CloseCpu (void) {
 		TerminateThread(hCPU, 0);
 
 		hCPU = NULL;
-		SetupPlugins(hMainWindow,FALSE);
 	}
 
 	CPURunning = FALSE;

--- a/Cpu.c
+++ b/Cpu.c
@@ -174,7 +174,7 @@ void CloseCpu (void) {
 	if (hCPU != NULL) { 
 		DisplayError("Emulation thread failed to terminate plugins\nReport this if you can reproduce reliably");
 
-		// This is a last resort when the audio thread refuses to gracefully exit.
+		// This is a last resort when the CPU thread refuses to gracefully exit.
 		// Calling this function WILL cause problems!
 		// SEE: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminatethread#remarks
 		TerminateThread(hCPU, 0);

--- a/Cpu.c
+++ b/Cpu.c
@@ -146,17 +146,19 @@ void CheckTimer (void) {
 void CloseCpu (void) {
 	DWORD ExitCode, OldProtect;
 	
-	if (!CPURunning || hCPU == NULL) { return; }
-	PauseCpu();
-	Sleep(50);
+	if (CPU_Action.CloseCPU || !CPURunning || hCPU == NULL) { return; }
+
+	// FIXME: Don't race global state like `CPU_Action` and `CPURunning` across multiple threads!!!
 	CPU_Action.CloseCPU = TRUE;
 	CPU_Action.Stepping = FALSE;
+	CPU_Action.DoInterrupt = FALSE;
+	CPU_Action.CheckInterrupts = FALSE;
 	CPU_Action.DoSomething = TRUE;
 	PulseEvent(CPU_Action.hStepping);
 
 	ManualPaused = FALSE;
 	if (CPU_Paused) { PauseCpu(); }
-	
+
 	{
 		BOOL Temp = AlwaysOnTop;
 		AlwaysOnTop = FALSE;
@@ -165,8 +167,9 @@ void CloseCpu (void) {
 	}
 
 	ExitCode = WaitForSingleObject(hCPU, 50);
-	if (ExitCode != WAIT_ABANDONED)
+	if (ExitCode == WAIT_OBJECT_0) {
 		hCPU = NULL;
+	}
 
 	if (hCPU != NULL) { 
 		DisplayError("Emulation thread failed to terminate plugins\nReport this if you can reproduce reliably");
@@ -183,12 +186,11 @@ void CloseCpu (void) {
 	CloseEeprom();
 	CloseMempak();
 	CloseSram();
-	FreeSyncMemory();	
-	/*
+	FreeSyncMemory();
 	if (GfxRomClosed != NULL) { GfxRomClosed(); }
-	if (ContRomClosed != NULL) { ContRomClosed(); }*/
-	if (AiRomClosed != NULL)   { AiRomClosed(); }	
-	if (RSPRomClosed) { RSPRomClosed(); }
+	if (ContRomClosed != NULL) { ContRomClosed(); }
+	if (AiRomClosed != NULL) { AiRomClosed(); }
+	if (RSPRomClosed != NULL) { RSPRomClosed(); }
 	if (Profiling) { GenerateTimerResults(); }
 	CloseHandle(CPU_Action.hStepping);
 	SendMessage( hStatusWnd, SB_SETTEXT, 0, (LPARAM)GS(MSG_EMULATION_ENDED) );
@@ -1190,7 +1192,6 @@ void SetCoreToSkipping(void) {
 
 void StartEmulation ( void ) {
 	DWORD ThreadID, count;
-	CloseCpu();
 
 	memset(&CPU_Action,0,sizeof(CPU_Action));
 	//memcpy(RomHeader,ROM,sizeof(RomHeader));
@@ -1209,8 +1210,9 @@ void StartEmulation ( void ) {
 	
 	RecompPos = RecompCode;
 
-	if (HaveDebugger)
-	Enable_R4300i_Commands_Window();
+	if (HaveDebugger) {
+		Enable_R4300i_Commands_Window();
+	}
 	if (InR4300iCommandsWindow) {
 		SetCoreToStepping();
 	}
@@ -1239,15 +1241,14 @@ void StartEmulation ( void ) {
 	CPURunning = TRUE;
 	SetupMenu(hMainWindow);
 
-	if (!inFullScreen)	// Only reset plugins if not in fullscreen
-		SetupPlugins(hMainWindow,TRUE);
-	else
+	if (inFullScreen) {
 		ResetAudio(hMainWindow);
+	}
 
 	switch (CPU_Type) {
 	case CPU_Interpreter: hCPU = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)StartInterpreterCPU,NULL,0, &ThreadID); break;
-	case CPU_Recompiler: hCPU = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)StartRecompilerCPU,NULL,0, &ThreadID);	break;
-	case CPU_SyncCores: hCPU = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)StartSyncCPU,NULL,0, &ThreadID);	 break;
+	case CPU_Recompiler: hCPU = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)StartRecompilerCPU,NULL,0, &ThreadID); break;
+	case CPU_SyncCores: hCPU = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)StartSyncCPU,NULL,0, &ThreadID); break;
 	default:
 		DisplayError("Unhandled CPU %d",CPU_Type);
 	}

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -733,8 +733,9 @@ void ExecuteInterpreterOpCode (void) {
 }
 
 void __cdecl StartInterpreterCPU (void ) { 
-	if (CoInitialize(NULL) != S_OK)
+	if (CoInitialize(NULL) != S_OK) {
 		return;
+	}
 
 	NextInstruction = NORMAL;
 

--- a/Main.c
+++ b/Main.c
@@ -52,7 +52,7 @@ IgnoreMove, Recursion, ShowPifRamErrors, LimitFPS, ShowCPUPer, AutoZip,
 AutoFullScreen, SystemABL, AlwaysOnTop, BasicMode, DelaySI, RememberCheats, AudioSignal, EmulateAI;
 unsigned int CurrentFrame;
 int CPU_Type, SystemCPU_Type, SelfModCheck, SystemSelfModCheck, RomsToRemember, RomDirsToRemember;
-HWND hMainWindow, hHiddenWin, hStatusWnd, hCheatSearchDlg;
+HWND hMainWindow, hStatusWnd, hCheatSearchDlg;
 char CurrentSave[256];
 HMENU hMainMenu;
 HINSTANCE hInst;
@@ -642,11 +642,9 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 
 	switch (uMsg) {
 		case WM_CREATE:
-			if (hHiddenWin) {
-				hStatusWnd = CreateStatusWindow(WS_CHILD | WS_VISIBLE, "", hWnd, 100);
-				SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
-				ChangeWinSize(hWnd, 640, 480, hStatusWnd);
-			}
+			hStatusWnd = CreateStatusWindow(WS_CHILD | WS_VISIBLE, "", hWnd, 100);
+			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
+			ChangeWinSize(hWnd, 640, 480, hStatusWnd);
 			break;
 
 		case WM_NCLBUTTONDBLCLK:
@@ -678,11 +676,6 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 				break;
 			}
 
-			if (hWnd == hHiddenWin) {
-				ValidateRect(hWnd, NULL);
-				break;
-			}
-
 			__try {
 				if (CPU_Paused && DrawScreen != NULL)
 					DrawScreen();
@@ -696,8 +689,9 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 			break;
 
 		case WM_MOVE:
-			if (IgnoreMove || hWnd == hHiddenWin)
+			if (IgnoreMove) {
 				break;
+			}
 
 			if (MoveScreen != NULL && CPURunning)
 				MoveScreen((int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam));
@@ -726,9 +720,6 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 			RECT clrect, swrect;
 			int Parts[2];
 
-			if (hWnd == hHiddenWin)
-				break;
-
 			GetClientRect(hWnd, &clrect);
 			GetClientRect(hStatusWnd, &swrect);
 
@@ -752,21 +743,17 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 		}
 
 		case WM_SETFOCUS:
-			if (hWnd == hHiddenWin)
-				break;
-
-			if (AutoSleep && !ManualPaused && (CPU_Paused || CPU_Action.Pause)) 
+			if (AutoSleep && !ManualPaused && (CPU_Paused || CPU_Action.Pause)) {
 				PauseCpu();
+			}
 
 			RomList_SetFocus();
 			break;
 
 		case WM_KILLFOCUS:
-			if (hWnd == hHiddenWin)
-				break;
-
-			if (AutoSleep && !CPU_Paused) 
+			if (AutoSleep && !CPU_Paused) {
 				PauseCpu();
+			}
 			break;
 
 		case WM_NOTIFY:
@@ -781,8 +768,9 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 			break;
 
 		case WM_DRAWITEM:
-			if (wParam == IDC_ROMLIST)
+			if (wParam == IDC_ROMLIST) {
 				RomListDrawItem((LPDRAWITEMSTRUCT)lParam);
+			}
 			break;
 
 		case WM_MENUSELECT:
@@ -987,35 +975,37 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 			break;
 
 		case WM_KEYDOWN:
-			if (!CPURunning || !hCPU)
+			if (CPU_Action.CloseCPU || !CPURunning || !hCPU) {
 				break;
+			}
 
 			if (WM_KeyDown)
 				WM_KeyDown(wParam, lParam);
 			break;
 
 		case WM_KEYUP:
-			if (!CPURunning || !hCPU)
+			if (CPU_Action.CloseCPU || !CPURunning || !hCPU) {
 				break;
+			}
 
-			if (WM_KeyUp)
+			if (WM_KeyUp) {
 				WM_KeyUp(wParam, lParam);
+			}
 			break;
 
 		//case WM_ERASEBKGND:
 		//	break;
 
 		case WM_USER + 10:
-			if (hWnd == hHiddenWin)
-				break;
-
 			if (!wParam) {
-				while (ShowCursor(FALSE) >= 0)
+				while (ShowCursor(FALSE) >= 0) {
 					Sleep(0);
+				}
 			}
 			else {
-				while (ShowCursor(TRUE) < 0)
+				while (ShowCursor(TRUE) < 0) {
 					Sleep(0);
+				}
 			}
 			break;
 
@@ -1127,10 +1117,16 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 					DestroyWindow(hWnd);
 					break;
 
-				case ID_CPU_RESET:
-					CloseCpu();
-					StartEmulation();
+				case ID_CPU_RESET: {
+					// FIXME: The CPU thread needs to be running to reset, but the threads have a ton of data races.
+					// Rapidly pressing F1 will cause the "Emulation thread failed to terminate plugins" error.
+					// This cannot be fixed without proper thread synchronization.
+					if (!CPU_Action.CloseCPU && CPURunning && hCPU) {
+						CloseCpu();
+						StartEmulation();
+					}
 					break;
+				}
 
 				case ID_CPU_PAUSE:
 					ManualPaused = TRUE;
@@ -2337,13 +2333,6 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 	AccelWinMode = LoadAccelerators(hInst, MAKEINTRESOURCE(IDR_WINDOWMODE));
 	AccelCPURunning = LoadAccelerators(hInst, MAKEINTRESOURCE(IDR_CPURUNNING));
 	AccelRomBrowser = LoadAccelerators(hInst, MAKEINTRESOURCE(IDR_ROMBROWSER));
-
-	hHiddenWin = CreateWindow(AppName, AppName, WS_OVERLAPPED | WS_CLIPCHILDREN |
-		WS_CLIPSIBLINGS | WS_SYSMENU | WS_MINIMIZEBOX, X, Y, WindowWidth, WindowHeight,
-		NULL, NULL, hInst, NULL
-	);
-
-	if (!hHiddenWin) { return FALSE; }
 
 	hMainWindow = CreateWindow(AppName, AppName, WS_OVERLAPPED | WS_CLIPCHILDREN |
 		WS_CLIPSIBLINGS | WS_SYSMENU | WS_MINIMIZEBOX, X, Y, WindowWidth, WindowHeight,

--- a/Main.c
+++ b/Main.c
@@ -2344,10 +2344,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 	if (!hMainWindow)
 		return FALSE;
 
+	SetupPlugins(hMainWindow);
+
 	if (strlen(lpszArgs) > 0) {
 		DWORD ThreadID;
 
-		SetupPlugins(hMainWindow,FALSE);
 		SetupMenu(hMainWindow);
 		ShowWindow(hMainWindow, nWinMode);
 
@@ -2366,7 +2367,6 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 			ShowRomList(hMainWindow);
 		}
 		else {
-			SetupPlugins(hMainWindow,FALSE);
 			SetupMenu(hMainWindow);
 			ShowWindow(hMainWindow, nWinMode);
 		}

--- a/Main.h
+++ b/Main.h
@@ -132,7 +132,7 @@ extern BOOL HaveDebugger, ShowDebugMessages, AutoLoadMapFile, ShowUnhandledMemor
 	AutoFullScreen, SystemABL, AlwaysOnTop, BasicMode, DelaySI, RememberCheats,AudioSignal, EmulateAI;
 extern unsigned int CurrentFrame;
 extern int CPU_Type, SystemCPU_Type, SelfModCheck, SystemSelfModCheck, RomsToRemember, RomDirsToRemember;
-extern HWND hMainWindow, hHiddenWin, hStatusWnd;
+extern HWND hMainWindow, hStatusWnd;
 extern char CurrentSave[256];
 extern HMENU hMainMenu;
 extern HINSTANCE hInst;

--- a/Plugin.c
+++ b/Plugin.c
@@ -355,7 +355,7 @@ void ResetAudio(HWND hWnd) {
 	}
 }
 
-void SetupPlugins (HWND hWnd, BOOL bDoInit) {
+void SetupPlugins (HWND hWnd) {
 	static DWORD AI_DUMMY = 0;
 	ShutdownPlugins();
 	GetCurrentDlls();
@@ -400,12 +400,9 @@ void SetupPlugins (HWND hWnd, BOOL bDoInit) {
 		GfxInfo.VI__X_SCALE_REG = &VI_X_SCALE_REG;
 		GfxInfo.VI__Y_SCALE_REG = &VI_Y_SCALE_REG;
 		
-		if (bDoInit)
-		{
-			if (!InitiateGFX(GfxInfo)) {
-				DisplayError(GS(MSG_FAIL_INIT_GFX));
-				PluginsInitilized = FALSE;
-			}
+		if (!InitiateGFX(GfxInfo)) {
+			DisplayError(GS(MSG_FAIL_INIT_GFX));
+			PluginsInitilized = FALSE;
 		}
 	}
 
@@ -441,25 +438,23 @@ void SetupPlugins (HWND hWnd, BOOL bDoInit) {
 		AudioInfo.AI__BITRATE_REG = &AI_BITRATE_REG;	
 		AudioInfo.CheckInterrupts = AiCheckInterrupts;
 		if (EmulateAI == TRUE) EmuAI_InitializePluginHook();
-		if (bDoInit)
-		{
-			if (!InitiateAudio(AudioInfo)) {
-				AiCloseDLL = NULL;
-				AiDacrateChanged = NULL;
-				AiLenChanged = NULL;
-				AiReadLength = NULL;
-				AiUpdate = NULL;
-				InitiateAudio = NULL;
-				ProcessAList = NULL;
-				AiRomClosed = NULL;
-				DisplayError(GS(MSG_FAIL_INIT_AUDIO));
-				PluginsInitilized = FALSE;
-			}
-			if (AiUpdate) {
-				DWORD ThreadID;
-				bTerminateAudioThread = FALSE;
-				hAudioThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)AudioThread, (LPVOID)NULL, 0, &ThreadID);
-			}
+		if (!InitiateAudio(AudioInfo)) {
+			AiCloseDLL = NULL;
+			AiDacrateChanged = NULL;
+			AiLenChanged = NULL;
+			AiReadLength = NULL;
+			AiUpdate = NULL;
+			InitiateAudio = NULL;
+			ProcessAList = NULL;
+			AiRomClosed = NULL;
+			DisplayError(GS(MSG_FAIL_INIT_AUDIO));
+			PluginsInitilized = FALSE;
+		}
+		if (AiUpdate) {
+			DWORD ThreadID;
+			bTerminateAudioThread = FALSE;
+			bAudioThreadExiting = FALSE;
+			hAudioThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)AudioThread, (LPVOID)NULL, 0, &ThreadID);
 		}
 	}
 
@@ -557,21 +552,18 @@ void SetupPlugins (HWND hWnd, BOOL bDoInit) {
 		RspInfo10.DPC__TMEM_REG = &DPC_TMEM_REG;
 		RspInfo11.DPC__TMEM_REG = &DPC_TMEM_REG;
 
-		if (bDoInit)
+		switch (RSPVersion)
 		{
-			switch (RSPVersion)
-			{
-			case 0x0100:
-				InitiateRSP_1_0(RspInfo10, &RspTaskValue);
-				break;
-			case 0x0101:
-			case 0x0102:
-				InitiateRSP_1_1(RspInfo11, &RspTaskValue);
-				break;
-			default:
-				InitiateRSP_1_0(RspInfo10, &RspTaskValue);
-				break;
-			}
+		case 0x0100:
+			InitiateRSP_1_0(RspInfo10, &RspTaskValue);
+			break;
+		case 0x0101:
+		case 0x0102:
+			InitiateRSP_1_1(RspInfo11, &RspTaskValue);
+			break;
+		default:
+			InitiateRSP_1_0(RspInfo10, &RspTaskValue);
+			break;
 		}
 
 		if (((DWORD)SetRomHeader) != NULL)
@@ -618,20 +610,17 @@ void SetupPlugins (HWND hWnd, BOOL bDoInit) {
 		Controllers[3].RawData = FALSE;
 		Controllers[3].Plugin  = PLUGIN_NONE;
 	
-		if (bDoInit)
-		{
-			if (ContVersion == 0x0100) {
-				InitiateControllers_1_0(hWnd, Controllers);
-			}
-			if (ContVersion == 0x0101) {
-				CONTROL_INFO ControlInfo;
-				ControlInfo.Controls = Controllers;
-				ControlInfo.HEADER = (BYTE*)RomHeader;
-				ControlInfo.hinst = hInst;
-				ControlInfo.hMainWindow = hWnd;
-				ControlInfo.MemoryBswaped = TRUE;
-				InitiateControllers_1_1(ControlInfo);
-			}
+		if (ContVersion == 0x0100) {
+			InitiateControllers_1_0(hWnd, Controllers);
+		}
+		if (ContVersion == 0x0101) {
+			CONTROL_INFO ControlInfo;
+			ControlInfo.Controls = Controllers;
+			ControlInfo.HEADER = (BYTE*)RomHeader;
+			ControlInfo.hinst = hInst;
+			ControlInfo.hMainWindow = hWnd;
+			ControlInfo.MemoryBswaped = TRUE;
+			InitiateControllers_1_1(ControlInfo);
 		}
 #ifndef EXTERNAL_RELEASE
 //		Controllers[0].Plugin  = PLUGIN_RUMBLE_PAK;

--- a/Plugin.h
+++ b/Plugin.h
@@ -419,7 +419,6 @@ void (__cdecl *RumbleCommand)	 ( int Control, BOOL bRumble );
 extern "C" {
 #endif
 void PluginConfiguration ( HWND hWnd );
-//void SetupPlugins        ( HWND hWnd );
 void SetupPlugins(HWND hWnd, BOOL bDoInit);
 void SetupPluginScreen   ( HWND hDlg );
 void ShutdownPlugins     ( void );

--- a/Plugin.h
+++ b/Plugin.h
@@ -419,7 +419,7 @@ void (__cdecl *RumbleCommand)	 ( int Control, BOOL bRumble );
 extern "C" {
 #endif
 void PluginConfiguration ( HWND hWnd );
-void SetupPlugins(HWND hWnd, BOOL bDoInit);
+void SetupPlugins(HWND hWnd);
 void SetupPluginScreen   ( HWND hDlg );
 void ShutdownPlugins     ( void );
 void ResetAudio(HWND hWnd);

--- a/Recompiler CPU.c
+++ b/Recompiler CPU.c
@@ -2859,8 +2859,10 @@ void MarkCodeBlock (DWORD PAddr) {
 void __cdecl StartRecompilerCPU (void ) { 
 	DWORD Addr;
 	BYTE * Block;
-		
-	CoInitialize(NULL);
+
+	if (CoInitialize(NULL) != S_OK) {
+		return;
+	}
 #ifdef Log_x86Code
 	Start_x86_Log();
 #endif
@@ -2902,6 +2904,9 @@ void __cdecl StartRecompilerCPU (void ) {
 			DWORD Value;
 
 			for (;;) {
+				if (CPU_Action.CloseCPU) {
+					DoSomething();
+				}
 				Addr = PROGRAM_COUNTER;
 				if (UseTlb) {
 					if (!TranslateVaddr(&Addr)) {

--- a/Rom.c
+++ b/Rom.c
@@ -993,7 +993,6 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 
 	if (!RememberCheats) { DisableAllCheats(); }
 	EnableOpenMenuItems();
-	//if (RomBrowser) { SetupPlugins(hMainWindow,FALSE); }
 	SetCurrentSaveState(hMainWindow, ID_CURRENTSAVE_DEFAULT);
 	sprintf(WinTitle, "%s - [ %s ]", GS(MSG_LOADED), FileName);
 	SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)WinTitle);

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -250,7 +250,6 @@ void HideRomBrowser(void) {
 
 	EnableWindow(hRomList, FALSE);
 	ShowWindow(hRomList, SW_HIDE);
-	SetupPlugins(hMainWindow,TRUE);
 
 	SendMessage(hMainWindow, WM_USER + 17, 0, 0);
 	ShowWindow(hMainWindow, SW_SHOW);
@@ -1076,8 +1075,6 @@ void SelectRomDir(void) {
 	}
 
 	CoUninitialize();
-
-	SetupPlugins(hMainWindow,FALSE);
 }
 
 void SetRomBrowserMaximized(BOOL Maximized) {
@@ -1163,8 +1160,7 @@ void ShowRomList(HWND hParent) {
 	if (hRomList != NULL && IsWindowVisible(hRomList))
 		return;
 	
-	SetupPlugins(hHiddenWin,TRUE);
-	//SetupPlugins(hMainWindow, TRUE);
+	SetupPlugins(hMainWindow, TRUE);
 	SetupMenu(hMainWindow);
 	IgnoreMove = TRUE;	
 	ShowWindow(hMainWindow, SW_HIDE);

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -1160,7 +1160,6 @@ void ShowRomList(HWND hParent) {
 	if (hRomList != NULL && IsWindowVisible(hRomList))
 		return;
 	
-	SetupPlugins(hMainWindow, TRUE);
 	SetupMenu(hMainWindow);
 	IgnoreMove = TRUE;	
 	ShowWindow(hMainWindow, SW_HIDE);

--- a/Settings.c
+++ b/Settings.c
@@ -660,13 +660,7 @@ BOOL CALLBACK PluginSelectProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			}
 			else {
 				ShutdownPlugins();
-				if (!RomBrowser) {
-					SetupPlugins(hMainWindow, TRUE);
-				}
-				if (RomBrowser) {
-					SetupPlugins(hHiddenWin,TRUE);
-					//SetupPlugins(hMainWindow, TRUE);
-				}
+				SetupPlugins(hMainWindow, TRUE);
 			}
 			FreePluginList();
 		}

--- a/Settings.c
+++ b/Settings.c
@@ -655,12 +655,12 @@ BOOL CALLBACK PluginSelectProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			if (CPURunning) {
 				CloseCpu();
 				ShutdownPlugins();
-				SetupPlugins(hMainWindow, TRUE);
+				SetupPlugins(hMainWindow);
 				StartEmulation();
 			}
 			else {
 				ShutdownPlugins();
-				SetupPlugins(hMainWindow, TRUE);
+				SetupPlugins(hMainWindow);
 			}
 			FreePluginList();
 		}


### PR DESCRIPTION
The reset functionality is still very broken. Too many data races between the GUI thread, CPU thread, and plugin threads.

This is at least a good start; resetting with F1 now works most of the time. I can still get it to throw the "Emulation thread failed to terminate plugins" error by hitting F1 ridiculously quickly with the recompiler core. It doesn't seem to break as badly with the interpreter.

Anyway, yeah, this is just lack of synchronization causing havok.

The hidden window was some kind of ludicrous hack by a previous contributor that attempted to hack around some other hacks, pile on some more hacks to "fix" the broken hacks, and we get what we have today.