### PR TITLE
Fix build problems

### DIFF
--- a/Project64.vcxproj
+++ b/Project64.vcxproj
@@ -61,14 +61,14 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>..\PJ64_1.6.2</OutDir>
+    <OutDir>..\PJ64_1.6.2\</OutDir>
     <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName)_Debug</TargetName>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>..\PJ64_1.6.2</OutDir>
+    <OutDir>..\PJ64_1.6.2\</OutDir>
     <IntDir>.\Release_External\</IntDir>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>$(ProjectName)_1.6.2</TargetName>
@@ -76,7 +76,7 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release for XP|Win32'">
-    <OutDir>..\PJ64_1.6.2</OutDir>
+    <OutDir>..\PJ64_1.6.2\</OutDir>
     <IntDir>.\Release_External\</IntDir>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>$(ProjectName)_1.6.2_XP</TargetName>

--- a/Project64.vcxproj
+++ b/Project64.vcxproj
@@ -191,8 +191,6 @@
     </Link>
     <Manifest>
       <GenerateCategoryTags>true</GenerateCategoryTags>
-    </Manifest>
-    <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -247,8 +245,6 @@
     </Link>
     <Manifest>
       <GenerateCategoryTags>true</GenerateCategoryTags>
-    </Manifest>
-    <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/Project64.vcxproj.filters
+++ b/Project64.vcxproj.filters
@@ -410,9 +410,6 @@
     <ClInclude Include="resource_cheat.h">
       <Filter>Header Files\General Header</Filter>
     </ClInclude>
-    <ClInclude Include="resource_cheatsearch.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="EmulateAI.h">
       <Filter>Header Files\Plugin Header</Filter>
     </ClInclude>


### PR DESCRIPTION
I was trying to find a way to fix the "file already in use" error when building for release. This happens when the manifest is embedded into the exe. StackOverflow said AV software was responsible. I tried some other workarounds but they all failed. In the end I had to add a local exception for my build directory to Windows Defender! Keep up the good work, MS.

On the other hand, I did fix that weird warning about the trailing path separator, and made some minor cleanups to the project file. So, we got that out of it.