### PR TITLE
Fix race condition when stopping the CPU while a watchpoint is trapped

### DIFF
--- a/Cpu.c
+++ b/Cpu.c
@@ -154,6 +154,9 @@ void CloseCpu (void) {
 	CPU_Action.DoInterrupt = FALSE;
 	CPU_Action.CheckInterrupts = FALSE;
 	CPU_Action.DoSomething = TRUE;
+
+	// The memory barrier will ensure that the writes above occur before the CPU is released from the stepping mode.
+	MemoryBarrier();
 	PulseEvent(CPU_Action.hStepping);
 
 	ManualPaused = FALSE;

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -762,6 +762,10 @@ void __cdecl StartInterpreterCPU (void ) {
 						Refresh_Memory();
 
 						WaitForSingleObject(CPU_Action.hStepping, INFINITE);
+
+						// The memory barrier ensures that CPU_Action.Stepping is up-to-date before looping
+						MemoryBarrier();
+
 						if (CPU_Action.Stepping)
 							ExecuteInterpreterOpCode();
 					} while (CPU_Action.Stepping);

--- a/Recompiler CPU.c
+++ b/Recompiler CPU.c
@@ -2904,9 +2904,6 @@ void __cdecl StartRecompilerCPU (void ) {
 			DWORD Value;
 
 			for (;;) {
-				if (CPU_Action.CloseCPU) {
-					DoSomething();
-				}
 				Addr = PROGRAM_COUNTER;
 				if (UseTlb) {
 					if (!TranslateVaddr(&Addr)) {


### PR DESCRIPTION
This uses strong (read and write) memory barriers to prevent instruction reordering when trying to stop the CPU thread while a watchpoint has trapped it.

The barrier strength can probably be reduced, but I'm a bit paranoid because the way this whole code base uses threads really has me on edge.