### PR TITLE
Add .editorconfig for project-wide editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/Project64.vcxproj
+++ b/Project64.vcxproj
@@ -404,6 +404,7 @@
     <ResourceCompile Include="PJ64_Cheat.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include=".editorconfig" />
     <None Include="PJ64.BMP" />
   </ItemGroup>
   <ItemGroup>

--- a/Project64.vcxproj.filters
+++ b/Project64.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -518,6 +518,7 @@
     <None Include="PJ64.BMP">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
     <Library Include="Compression\zlibstat.lib" />


### PR DESCRIPTION
- Save all files with UTF-8 encoding.
- Add a final newline.
- Trim trailing whitespace from all lines.

This configures VS to save files with a certain amount of consistency. I haven't decided to make it use any specific indentation style, but we could settle on tabs with tab-width=4. Which seems to be the default anyway.

Adding this config gives us some control over accidentally making unnecessary changes. I.e., it helps keep git history clean. VS likes to let the user add trailing whitespace for no reason at all, and these lines end up getting changed by unrelated edits when someone else saves with trim-trailing-whitespace enabled.

The UTF-8 encoding is the most important setting, because GitHub does not support rendering UTF-16 (Windows default "Unicode" encoding) in the web app.

There will be some amount of churn as all files are normalized to the new settings over time. It could be done in one push, but I've decided not to for now, just to keep this PR small and easy to review.