### PR TITLE
Support for DMAs in watchpoint handler

### DIFF
--- a/BreakPoints.c
+++ b/BreakPoints.c
@@ -122,8 +122,11 @@ void BPoint_AddButtonPressed (void) {
 				SetFocus(hR4300iLocation);
 			}
 		} else {
-			AddWatchPoint(Location, BreakType);
-			RefreshBreakPoints();
+			if (AddWatchPoint(Location, BreakType)) {
+				RefreshBreakPoints();
+			} else {
+				DisplayError("Invalid watchpoint address: 0x%08X\nTLB-mapped address support is a work in progress", AsciiToHex(Address));
+			}
 		}
 		break;
 	}

--- a/Memory.c
+++ b/Memory.c
@@ -2972,6 +2972,8 @@ int r4300i_SW_NonMemory ( DWORD PAddr, DWORD Value ) {
 		case 0x04500000: AI_DRAM_ADDR_REG = (Value & 0xFFFFF8); break;
 		case 0x04500004: 
 			AI_LEN_REG = Value;  
+			MIPS_DWORD dram_addr = { .UDW = AI_DRAM_ADDR_REG };
+			CheckForWatchPoint(dram_addr, WP_READ, AI_LEN_REG + 1);
 			if (AiLenChanged != NULL) { AiLenChanged(); }
 			break;
 		case 0x04500008: AI_CONTROL_REG = (Value & 1); break;

--- a/WatchPoints.h
+++ b/WatchPoints.h
@@ -29,12 +29,15 @@
 #include "Types.h"
 
 typedef enum {
-	WP_NONE,
-	WP_READ,
-	WP_WRITE,
-	WP_READ_WRITE,
-	WP_ENABLED,
+	WP_NONE,		// 0b0000
+	WP_READ,		// 0b0001
+	WP_WRITE,		// 0b0010
+	WP_READ_WRITE,	// 0b0011
+	WP_ENABLED,		// 0b0100
 } WATCH_TYPE;
+
+// The mask that defines "all bits enabled" in a WATCH_TYPE value.
+#define WATCH_TYPE_MASK 7
 
 void InitWatchPoints(void);
 BOOL AddWatchPoint(MIPS_DWORD Location, WATCH_TYPE Type);

--- a/WatchPoints.h
+++ b/WatchPoints.h
@@ -37,7 +37,7 @@ typedef enum {
 } WATCH_TYPE;
 
 void InitWatchPoints(void);
-void AddWatchPoint(MIPS_DWORD Location, WATCH_TYPE Type);
+BOOL AddWatchPoint(MIPS_DWORD Location, WATCH_TYPE Type);
 void RemoveWatchPoint(MIPS_DWORD Location);
 void ToggleWatchPoint(MIPS_DWORD Location);
 void RemoveAllWatchPoints(void);


### PR DESCRIPTION
This partially resolves points 2, 3 and 4 in #49.

For point 2, watchpoint addresses are now normalized to physical address space. The GUI will reject addresses outside of KSEG0 and KSEG1, but will allow addresses below 0x2000_0000; they just get interpreted as physical addresses. (This is the wrong way to do it, but it was easy.)

For point 3, DMAs started by VR4300 now notify the debugger when memory accesses occur. DMAs started by plugins do not (point 5).

For point 4, DMAs are able to be compared against watchpoints over a large memory range. Users are NOT able to define watchpoints over a range yet; that requires UI and watchpoint API changes.

The watchpoint API changes needed are passing a "size" parameter when adding, removing, and toggling watchpoints, so that it can iterate over the full range in the watchpoints map.