### PR TITLE
Add TLB Miss exceptions to interpreter

### DIFF
--- a/Exception.c
+++ b/Exception.c
@@ -143,8 +143,8 @@ void DoIntrException ( BOOL DelaySlot ) {
 	PROGRAM_COUNTER = 0x80000180;
 }
 
-void _fastcall DoTLBMiss ( BOOL DelaySlot, DWORD BadVaddr ) {
-	CAUSE_REGISTER = EXC_RMISS;
+void _fastcall DoTLBMiss ( BOOL DelaySlot, DWORD BadVaddr, BOOL FromRead ) {
+	CAUSE_REGISTER = FromRead ? EXC_RMISS : EXC_WMISS;
 	BAD_VADDR_REGISTER = BadVaddr;
 	CONTEXT_REGISTER &= 0xFF80000F;
 	CONTEXT_REGISTER |= (BadVaddr >> 9) & 0x007FFFF0;

--- a/Exception.h
+++ b/Exception.h
@@ -69,7 +69,7 @@ void __cdecl CheckInterrupts			( void );
 void DoAddressError						( BOOL DelaySlot, DWORD BadVaddr, BOOL FromRead );
 void _fastcall DoCopUnusableException	( BOOL DelaySlot, int Coprocessor );
 void DoIntrException					( BOOL DelaySlot );
-void _fastcall DoTLBMiss				( BOOL DelaySlot, DWORD BadVaddr );
+void _fastcall DoTLBMiss				( BOOL DelaySlot, DWORD BadVaddr, BOOL FromRead );
 void _fastcall DoSysCallException		( BOOL DelaySlot );
 void _fastcall DoBreakException			( BOOL DelaySlot );
 void _fastcall DoIllegalInstructionException(BOOL DelaySlot );

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -677,7 +677,7 @@ void BuildInterpreter (void ) {
 
 void ExecuteInterpreterOpCode (void) {
 	if (!r4300i_LW_VAddr_NonCPU(PROGRAM_COUNTER, &Opcode.Hex)) {
-		DoTLBMiss(NextInstruction == JUMP, PROGRAM_COUNTER);
+		DoTLBMiss(NextInstruction == JUMP, PROGRAM_COUNTER, TRUE);
 		NextInstruction = NORMAL;
 		return;
 	}

--- a/Recompiler CPU.c
+++ b/Recompiler CPU.c
@@ -605,6 +605,7 @@ void CompileExit (DWORD TargetPC, REG_INFO ExitRegSet, int reason, int CompileNo
 	case TLBReadMiss:
 		MoveConstToX86reg(NextInstruction == JUMP || NextInstruction == DELAY_SLOT,x86_ECX);
 		MoveVariableToX86reg(&TLBLoadAddress,"TLBLoadAddress",x86_EDX);
+		PushImm32("FromRead", 1);
 		Call_Direct(DoTLBMiss,"DoTLBMiss");
 		if (CPU_Type == CPU_SyncCores) { Call_Direct(SyncToPC, "SyncToPC"); }
 		Ret();
@@ -2930,7 +2931,7 @@ void __cdecl StartRecompilerCPU (void ) {
 				Addr = PROGRAM_COUNTER;
 				if (UseTlb) {
 					if (!TranslateVaddr(&Addr)) {
-						DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER);
+						DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER, TRUE);
 						NextInstruction = NORMAL;
 						Addr = PROGRAM_COUNTER;
 						if (!TranslateVaddr(&Addr)) {
@@ -3056,7 +3057,7 @@ void __cdecl StartRecompilerCPU (void ) {
 			Addr = PROGRAM_COUNTER;
 			if (UseTlb) {
 				if (!TranslateVaddr(&Addr)) {
-					DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER);
+					DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER, TRUE);
 					NextInstruction = NORMAL;
 					Addr = PROGRAM_COUNTER;
 					if (!TranslateVaddr(&Addr)) {

--- a/Sync CPU.c
+++ b/Sync CPU.c
@@ -259,7 +259,7 @@ void __cdecl StartSyncCPU (void ) {
 			Addr = PROGRAM_COUNTER;
 			if (UseTlb) {
 				if (!TranslateVaddr(&Addr)) {
-					DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER);
+					DoTLBMiss(NextInstruction == DELAY_SLOT,PROGRAM_COUNTER, TRUE);
 					NextInstruction = NORMAL;
 					Addr = PROGRAM_COUNTER;
 					if (!TranslateVaddr(&Addr)) {


### PR DESCRIPTION
- Only some load instructions raised the TLB miss exception. Now they all do! And all store instructions, as well.
- Doesn't add TLB Miss to the recompiler (looks like only stores are missing there).
- Fixes Re-Volt! Gauntlet Legends now shows garbage on the screen instead of nothing.