### PR TITLE
Setup plugins after resetting audio

### DIFF
--- a/Cpu.c
+++ b/Cpu.c
@@ -1267,6 +1267,7 @@ void StartEmulation ( void ) {
 
 	if (inFullScreen) {
 		ResetAudio(hMainWindow);
+		SetupPlugins(hMainWindow);
 	}
 
 	switch (CPU_Type) {

--- a/RomBrowser.cpp
+++ b/RomBrowser.cpp
@@ -1047,6 +1047,7 @@ void SelectRomDir(void) {
 	BROWSEINFO bi = { 0 };	// Initialization to 0 prevents XP crash
 	
 	TerminateAudioThread();
+	SetupPlugins(hMainWindow);
 
 	Settings_GetDirectory(RomDir, RomDirectory, sizeof(RomDirectory));
 


### PR DESCRIPTION
- This happens in two places: When loading a new ROM directory, and when resetting the game in full screen.
- I have no idea why the audio reset is needed. Maybe this is wrong. But plugins need to be reloading after the audio is torn down!