### PR TITLE
Fix APPS file corruption

### DIFF
--- a/Cheat.c
+++ b/Cheat.c
@@ -481,7 +481,7 @@ BOOL CheatActive(char* Name) {
 /********************************************************************************************
   CheatCodeExProc
 
-  Purpose: Message handler for
+  Purpose: Message handler for ... who knows! Git blame me, I dare you! ROFL
   Parameters:
   Returns:
 

--- a/Cheats_Preprocessor.c
+++ b/Cheats_Preprocessor.c
@@ -215,6 +215,8 @@ void Cheats_Delete(CHEAT* cheat) {
 	}
 
 	// To do! Remove this hack once the file handler has been updated to do delayed/timed writes
+	// See "very hacky" comment in FileHandler.cpp:WriteHandler() for some context.
+	// I guess adding a Flush() function was just too much to ask?
 	Settings_Delete(CDB_NAME, Identifier, "Cheat9000");
 
 	// Remove the cheat from the APPS file
@@ -226,7 +228,7 @@ void Cheats_Delete(CHEAT* cheat) {
 	if (!tmp)
 		return;
 	snprintf(tmp, length, CHT_EXT_O, cheat->name);
-	Settings_Delete(APPS_NAME, Identifier, cheat->name);
+	Settings_Delete(APPS_NAME, Identifier, tmp);
 }
 
 

--- a/FileHandler.cpp
+++ b/FileHandler.cpp
@@ -257,6 +257,11 @@ void FileStuff::RemoveSetting(char* id, char* setting) {
 	if (del_start != entry->data.end()) {
 		entry->data.erase(del_start, entry->data.end());
 	}
+
+	// Remove entry if it is empty
+	if (entry->data.empty()) {
+		RemoveEntry(id);
+	}
 }
 
 void FileStuff::RemoveEntry(char* id) {

--- a/Project64.vcxproj.filters
+++ b/Project64.vcxproj.filters
@@ -11,9 +11,6 @@
     <Filter Include="Source Files\General Source">
       <UniqueIdentifier>{b794c654-9162-402c-98d3-eaf1a7435642}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\Zlib Source">
-      <UniqueIdentifier>{500c7cae-17df-494b-9fa1-36a78c46255a}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\Plugin Source">
       <UniqueIdentifier>{2ca13adb-0ac4-4e5f-98d2-bc5f5d51d6fb}</UniqueIdentifier>
     </Filter>
@@ -61,9 +58,6 @@
     <Filter Include="Source Files\CPU Source\Save Chips">
       <UniqueIdentifier>{578ac748-582b-44bf-90ed-775c3c974d74}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\General Source\Settings Api 2">
-      <UniqueIdentifier>{46a311cd-c148-4272-818a-86090b12be1b}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\General Header\Settings Api 2">
       <UniqueIdentifier>{f467e0bd-d869-492c-930a-09d9cbf98618}</UniqueIdentifier>
     </Filter>
@@ -72,6 +66,9 @@
     </Filter>
     <Filter Include="Header Files\cbor-lite Headers">
       <UniqueIdentifier>{c59b946f-43e7-4676-8b2b-840d70c41937}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Compression Source">
+      <UniqueIdentifier>{500c7cae-17df-494b-9fa1-36a78c46255a}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -210,80 +207,80 @@
     <ClCompile Include="CheatSearch_Input.c">
       <Filter>Source Files\General Source</Filter>
     </ClCompile>
-    <ClCompile Include="Settings Api.c">
-      <Filter>Source Files\General Source\Settings Api 2</Filter>
-    </ClCompile>
-    <ClCompile Include="FileHandler.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\unzip.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\zip.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\ioapi.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\crc32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\inflate.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\zutil.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\inftrees.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\inffast.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\deflate.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\compress.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\gzclose.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\gzlib.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\gzread.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\gzwrite.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\infback.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\trees.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\uncompr.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Compression\adler32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="CheatSearch_Dev.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="CheatSearch_Search.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Cheats_Preprocessor.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="WatchPoints.cpp">
       <Filter>Source Files\Debugger Source</Filter>
     </ClCompile>
+    <ClCompile Include="Compression\adler32.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\compress.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\crc32.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\deflate.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\gzclose.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\gzlib.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\gzread.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\gzwrite.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\infback.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\inffast.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\inflate.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\inftrees.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\ioapi.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\uncompr.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\unzip.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\zip.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\zutil.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Cheats_Preprocessor.c">
+      <Filter>Source Files\General Source</Filter>
+    </ClCompile>
+    <ClCompile Include="CheatSearch_Dev.c">
+      <Filter>Source Files\General Source</Filter>
+    </ClCompile>
+    <ClCompile Include="CheatSearch_Search.c">
+      <Filter>Source Files\General Source</Filter>
+    </ClCompile>
+    <ClCompile Include="FileHandler.cpp">
+      <Filter>Source Files\General Source</Filter>
+    </ClCompile>
     <ClCompile Include="Sessions.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\General Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Compression\trees.c">
+      <Filter>Source Files\Compression Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings Api.c">
+      <Filter>Source Files\General Source</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -539,9 +536,6 @@
     <None Include=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <Library Include="Compression\zlibstat.lib" />
-  </ItemGroup>
-  <ItemGroup>
     <Image Include="PJ64_2.bmp">
       <Filter>Resource Files</Filter>
     </Image>
@@ -551,5 +545,10 @@
   </ItemGroup>
   <ItemGroup>
     <Text Include="About.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Library Include="Compression\zlibstat.lib">
+      <Filter>Lib Files</Filter>
+    </Library>
   </ItemGroup>
 </Project>

--- a/r4300i Registers.c
+++ b/r4300i Registers.c
@@ -53,32 +53,7 @@ void PaintR4300iGPRPanel               ( HWND );
 void PaintR4300iMIPanel                ( HWND );
 void PaintR4300iRDRamPanel             ( HWND );
 void PaintR4300iPIPanel                ( HWND );
-void PaintR4300iRIPanel                ( HWND );/*
- * Project 64 - A Nintendo 64 emulator.
- *
- * (c) Copyright 2001 zilmar (zilmar@emulation64.com) and 
-  * Jabo (jabo@emulation64.com).
- *
- * pj64 homepage: www.pj64.net
- *
- * Permission to use, copy, modify and distribute Project64 in both binary and
- * source form, for non-commercial purposes, is hereby granted without fee,
- * providing that this license information and copyright notice appear with
- * all copies and any derived work.
- *
- * This software is provided 'as-is', without any express or implied
- * warranty. In no event shall the authors be held liable for any damages
- * arising from the use of this software.
- *
- * Project64 is freeware for PERSONAL USE only. Commercial users should
- * seek permission of the copyright holders first. Commercial use includes
- * charging money for Project64 or software derived from Project64.
- *
- * The copyright holders request that bug fixes and improvements to the code
- * should be forwarded to them so if they want them.
- *
-*/
-
+void PaintR4300iRIPanel                ( HWND );
 void PaintR4300iSIPanel                ( HWND );
 void PaintR4300iSPPanel                ( HWND );
 void PaintR4300iSpecialPanel           ( HWND );


### PR DESCRIPTION
Here are the steps to reproduce the corruption. After applying this patch, these steps should no longer leave the APPS file in a state that the emulator cannot handle.

1. Setup: Enable "Remember selected cheats" in options.

2. Pick two games, A and B. I'll use Body Harvest as A, and Donkey Kong 64 as B.
    **IMPORTANT**: Make sure these two games have not had any cheats saved before! You may have to manually remove the `[XXXXXXXX-XXXXXXXX-C:XX]` sections in the APPS file by hand.

3. Edit cheats for game A: Add a new cheat and enable it. This should add a new entry to the APPS file.

4. Edit cheats for game B: Enable any cheat. This should add another new entry to the APPS file, directly following the entry for game A.

5. Edit cheats for game A again: Delete the cheat that you added in step 3. This should remove the saved cheat name from the APPS file but leave an empty section for game A directly preceeding the section for game B. This is the corruption.

6. Close PJ64 and try to open it. It will not open until the corruption is resolved (manually remove the empty section from the APPS file for game A).