### PR TITLE
Improvements for the recompiler log

### DIFF
--- a/CPU Log.c
+++ b/CPU Log.c
@@ -60,10 +60,10 @@ void Start_x86_Log (void) {
 		CREATE_ALWAYS,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
 	if (hCPULogFile == INVALID_HANDLE_VALUE) {
 		DWORD error_code = GetLastError();
-		TCHAR *error = NULL;
+		LPSTR error = NULL;
 		FormatMessage(
 			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, error_code, 0, &error, 0, NULL
+			NULL, error_code, 0, (LPSTR)&error, 0, NULL
 		);
 		if (error != NULL) {
 			DisplayError("Unable to create CPUoutput.log file:\n%s", error);

--- a/CPU Log.c
+++ b/CPU Log.c
@@ -63,9 +63,14 @@ void Start_x86_Log (void) {
 		TCHAR *error = NULL;
 		FormatMessage(
 			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, error_code, 0, &error, 1, NULL
+			NULL, error_code, 0, &error, 0, NULL
 		);
-		DisplayError("Unable to create CPUoutput.log file:\n%s", error);
+		if (error != NULL) {
+			DisplayError("Unable to create CPUoutput.log file:\n%s", error);
+			LocalFree(error);
+		} else {
+			DisplayError("Unable to create CPUoutput.log file:\nNo extra information is available");
+		}
 	} else {
 		SetFilePointer(hCPULogFile, 0, NULL, FILE_BEGIN);
 	}

--- a/CPU Log.c
+++ b/CPU Log.c
@@ -58,7 +58,17 @@ void Start_x86_Log (void) {
 	if (hCPULogFile) { Stop_x86_Log(); }
 	hCPULogFile = CreateFile(LogFileName,GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE,NULL,
 		CREATE_ALWAYS,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-	SetFilePointer(hCPULogFile,0,NULL,FILE_BEGIN);
+	if (hCPULogFile == INVALID_HANDLE_VALUE) {
+		DWORD error_code = GetLastError();
+		TCHAR *error = NULL;
+		FormatMessage(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, error_code, 0, &error, 1, NULL
+		);
+		DisplayError("Unable to create CPUoutput.log file:\n%s", error);
+	} else {
+		SetFilePointer(hCPULogFile, 0, NULL, FILE_BEGIN);
+	}
 }
 
 void Stop_x86_Log (void) {
@@ -67,4 +77,4 @@ void Stop_x86_Log (void) {
 		hCPULogFile = NULL;
 	}
 }
-#endif 
+#endif

--- a/Cpu.c
+++ b/Cpu.c
@@ -209,6 +209,10 @@ void CloseCpu (void) {
 		}
 	} while (hCPU != NULL);
 
+#ifdef Log_x86Code
+	Stop_x86_Log();
+#endif
+
 	CPURunning = FALSE;
 	VirtualProtect(N64MEM,RdramSize,PAGE_READWRITE,&OldProtect);
 	VirtualProtect(N64MEM + 0x04000000,0x2000,PAGE_READWRITE,&OldProtect);

--- a/Project64.vcxproj.filters
+++ b/Project64.vcxproj.filters
@@ -36,9 +36,6 @@
     <Filter Include="Header Files\CPU Header\Save Chips headers">
       <UniqueIdentifier>{88d6d629-3384-4395-90e7-65353ef87f57}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Header Files\Zlib Header">
-      <UniqueIdentifier>{31849a03-28d6-477f-bb84-61ef4162340f}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\Plugin Header">
       <UniqueIdentifier>{19a75cb1-af13-43a4-9405-f28bedb8f8ea}</UniqueIdentifier>
     </Filter>
@@ -69,6 +66,9 @@
     </Filter>
     <Filter Include="Source Files\Compression Source">
       <UniqueIdentifier>{500c7cae-17df-494b-9fa1-36a78c46255a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Compression Headers">
+      <UniqueIdentifier>{31849a03-28d6-477f-bb84-61ef4162340f}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -398,9 +398,6 @@
     <ClInclude Include="Language.h">
       <Filter>Header Files\Lang Header</Filter>
     </ClInclude>
-    <ClInclude Include="MemTest.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="n64_cic_nus_6105.h">
       <Filter>Header Files\General Header</Filter>
     </ClInclude>
@@ -431,66 +428,6 @@
     <ClInclude Include="Settings Api.h">
       <Filter>Header Files\General Header\Settings Api 2</Filter>
     </ClInclude>
-    <ClInclude Include="Settings Common Defines.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FileHandler.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\unzip.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\zconf.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\zip.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\zlib.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\ioapi.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\crc32.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\inflate.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\zutil.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\inftrees.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\gzguts.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\inffast.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\inffixed.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\deflate.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Compression\trees.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CheatSearch_Dev.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CheatSearch_Search.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Cheats_Preprocessor.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="xxhash64.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="WatchPoints.h">
       <Filter>Header Files\Debugger Headers</Filter>
     </ClInclude>
@@ -500,11 +437,74 @@
     <ClInclude Include="cbor-lite\codec-fp.h">
       <Filter>Header Files\cbor-lite Headers</Filter>
     </ClInclude>
+    <ClInclude Include="Cheats_Preprocessor.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="CheatSearch_Dev.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="CheatSearch_Search.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\crc32.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\deflate.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\gzguts.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\inffast.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\inffixed.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\inflate.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\inftrees.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\ioapi.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\trees.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\unzip.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\zconf.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\zip.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\zlib.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Compression\zutil.h">
+      <Filter>Header Files\Compression Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="FileHandler.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
     <ClInclude Include="SessionMemBookmarks.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\General Header</Filter>
     </ClInclude>
     <ClInclude Include="Sessions.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings Common Defines.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="MemTest.h">
+      <Filter>Header Files\General Header</Filter>
+    </ClInclude>
+    <ClInclude Include="xxhash64.h">
+      <Filter>Header Files\General Header</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/r4300i Memory.c
+++ b/r4300i Memory.c
@@ -24,7 +24,7 @@
  *
  */
 
-// Required for WIndows XP build profile
+// Required for Windows XP build profile
 #ifndef _WIN32_WINNT_WIN8
 #define _WIN32_WINNT_WIN8 0x0602
 #endif


### PR DESCRIPTION
- Shows an error message when the log file cannot be created.
- Closes the log file when the CPU is stopped. Making the log contents
  available without requiring closing the whole emulator.
- More project cleanups.