### PR TITLE
Fix some crashes in the debug tools

### DIFF
--- a/MemDump.c
+++ b/MemDump.c
@@ -335,15 +335,10 @@ void DumpPCAndDisassembled (HWND hDlg, DWORD startAddress, DWORD endAddress) {
 		location = startAddress - startAddress % 4;
 		while (location < endAddress) {
 			validOpCode = TRUE;
-			__try {
-				if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
-					fprintf(pFile, " 0x%08X\tCould not resolve address\n", location);
-					validOpCode = FALSE;
-				}
-			} __except( r4300i_Command_MemoryFilter( GetExceptionCode(), GetExceptionInformation()) ) {
-				DisplayError(GS(MSG_UNKNOWN_MEM_ACTION));
-				ExitThread(0);
-			}	
+			if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
+				fprintf(pFile, " 0x%08X\tCould not resolve address\n", location);
+				validOpCode = FALSE;
+			}
 
 			if (validOpCode) {
 				if (CPU_Type == CPU_Recompiler && SelfModCheck == ModCode_ChangeMemory) {

--- a/Memory.h
+++ b/Memory.h
@@ -38,7 +38,6 @@ int  Allocate_Memory             ( void );
 void Release_Memory              ( void );
 
 /* CPU memory functions */
-int  r4300i_Command_MemoryFilter ( DWORD dwExptCode, LPEXCEPTION_POINTERS lpEP );
 int  r4300i_CPU_MemoryFilter     ( DWORD dwExptCode, LPEXCEPTION_POINTERS lpEP );
 int  r4300i_LB_NonMemory         ( DWORD PAddr, DWORD * Value, BOOL SignExtend );
 BOOL r4300i_LB_VAddr             ( DWORD VAddr, BYTE * Value );

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -165,24 +165,19 @@ int DisplayR4300iCommand (DWORD location, int InsertPos) {
 	}
 
 	Redraw = FALSE;
-	__try {
-		if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
-			r4300iCommandLine[InsertPos].Location = location;
-			r4300iCommandLine[InsertPos].status = 0;
-			sprintf(r4300iCommandLine[InsertPos].String," 0x%08X\tCould not resolve address",location);
-			if ( SendMessage(hList,LB_GETCOUNT,0,0) <= InsertPos) {
-				SendMessage(hList,LB_INSERTSTRING,(WPARAM)InsertPos, (LPARAM)location); 
-			} else {
-				RECT ItemRC;
-				SendMessage(hList, LB_GETITEMRECT, (WPARAM)InsertPos, (LPARAM)&ItemRC);
-				RedrawWindow(hList, &ItemRC, NULL, RDW_INVALIDATE);
-			}
-			return LinesUsed;
+	if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
+		r4300iCommandLine[InsertPos].Location = location;
+		r4300iCommandLine[InsertPos].status = 0;
+		sprintf(r4300iCommandLine[InsertPos].String," 0x%08X\tCould not resolve address",location);
+		if ( SendMessage(hList,LB_GETCOUNT,0,0) <= InsertPos) {
+			SendMessage(hList,LB_INSERTSTRING,(WPARAM)InsertPos, (LPARAM)location); 
+		} else {
+			RECT ItemRC;
+			SendMessage(hList, LB_GETITEMRECT, (WPARAM)InsertPos, (LPARAM)&ItemRC);
+			RedrawWindow(hList, &ItemRC, NULL, RDW_INVALIDATE);
 		}
-	} __except( r4300i_Command_MemoryFilter( GetExceptionCode(), GetExceptionInformation()) ) {
-		DisplayError(GS(MSG_UNKNOWN_MEM_ACTION));
-		ExitThread(0);
-	}					
+		return LinesUsed;
+	}
 	if (SelfModCheck == ModCode_ChangeMemory) {
 		if ( (OpCode >> 16) == 0x7C7C) {
 			OpCode = OrigMem[(OpCode & 0xFFFF)].OriginalValue;
@@ -225,15 +220,9 @@ int WriteR4300iCommand(char *commands, DWORD location) {
 		}
 	}
 
-	__try {
-		if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
-			res += sprintf(commands, "0x%08X  Could not resolve address\r\n", location);
-			return res;
-		}
-	}
-	__except (r4300i_Command_MemoryFilter(GetExceptionCode(), GetExceptionInformation())) {
-		DisplayError(GS(MSG_UNKNOWN_MEM_ACTION));
-		ExitThread(0);
+	if (!r4300i_LW_VAddr_NonCPU(location, &OpCode)) {
+		res += sprintf(commands, "0x%08X  Could not resolve address\r\n", location);
+		return res;
 	}
 	if (SelfModCheck == ModCode_ChangeMemory) {
 		if ((OpCode >> 16) == 0x7C7C) {


### PR DESCRIPTION
This removes one of the two exception handlers (using SEH). This is the easy one, because it's completely outside of the critical path. None of the core emulation uses it. The "command" exception handler is specific to debug tools and cheats.

There is absolutely no use for the exception handler! It adds extra overhead (See https://preshing.com/20110807/the-cost-of-enabling-exception-handling/) just to save one or two branches. It's a headache to debug, it obscures control flow, and the x86 disassembler that it requires is notoriously incomplete and buggy.

Some people might be more concerned about the cost of those branches on the critical path, so it is not getting changed here. (Side note: any concerns about the branches on the critical path should also be just as concerned about the SEH overhead on the critical path, but let's table that conversation for now.)

This fixes a crash in the memory editor bookmarking non-RDRAM addresses and many of the debug tools in the debug build. This latter crash was pure gold caused by the EDX register randomly becoming the load destination chosen by the compiler, but the exception handler hadn't been updated for it!

I didn't want to rewrite the whole x86 disassembler that has to exist in the "CPU" exception handler... It's bad enough that the exception handler exists at all. The best solution was just to remove it.

As a nice bonus, removing the exception handler also simplifies the control flow, which is now explicit as you read the code. No surprises!