### PR TITLE
Memory-mapped ROM file

### DIFF
--- a/Dma.c
+++ b/Dma.c
@@ -179,12 +179,6 @@ void PI_DMA_WRITE (void) {
 	}
 	
 	if ( PI_CART_ADDR_REG >= 0x06000000 && PI_CART_ADDR_REG < 0x08000000) {
-#ifdef ROM_IN_MAPSPACE
-		if (WrittenToRom) { 
-			DWORD OldProtect;
-			VirtualProtect(ROM,RomFileSize,PAGE_READONLY, &OldProtect);
-		}
-#endif
 		PI_CART_ADDR_REG -= 0x06000000;
 		if (PI_CART_ADDR_REG + PI_WR_LEN_REG + 1 < RomFileSize) {
 			for (i = 0; i < PI_WR_LEN_REG + 1; i ++) {
@@ -221,12 +215,6 @@ void PI_DMA_WRITE (void) {
 	}
 
 	if ( PI_CART_ADDR_REG >= 0x10000000 && PI_CART_ADDR_REG <= 0x1FBFFFFF) {
-#ifdef ROM_IN_MAPSPACE
-		if (WrittenToRom) { 
-			DWORD OldProtect;
-			VirtualProtect(ROM,RomFileSize,PAGE_READONLY, &OldProtect);
-		}
-#endif
 		PI_CART_ADDR_REG -= 0x10000000;
 		if (PI_CART_ADDR_REG + PI_WR_LEN_REG + 1 < RomFileSize) {
 			for (i = 0; i < PI_WR_LEN_REG + 1; i ++) {

--- a/Language.cpp
+++ b/Language.cpp
@@ -378,7 +378,7 @@ LANG_STR DefaultString[] = {
 	{ MSG_CHEAT_NAME_IN_USE,  "Cheat Name is already in use"},
 	{ MSG_MAX_CHEATS,         "You Have reached the Maxiumn amount of cheats for this rom"},
 	{ MSG_NO_GAME_INFORMATION,"No game information available"},
-
+	{ MSG_FAIL_CREATE_TEMP,	  "Unable to create temporary ROM file"},
 };
 
 class CLanguage  {

--- a/Language.h
+++ b/Language.h
@@ -427,3 +427,4 @@ char * GS               ( int StringID );
 #define MSG_CHEAT_NAME_IN_USE   2043
 #define MSG_MAX_CHEATS          2044
 #define MSG_NO_GAME_INFORMATION	2045
+#define MSG_FAIL_CREATE_TEMP	2046

--- a/Main.c
+++ b/Main.c
@@ -1103,6 +1103,7 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 					}
 
 					CloseCpu();
+					CloseTempRomFile();
 					hMenu = GetMenu(hMainWindow);
 					EnableMenuItem(hMenu, ID_FILE_STARTEMULATION, MFS_ENABLED | MF_BYCOMMAND);
 					if (DrawScreen != NULL) 

--- a/Recompiler CPU.c
+++ b/Recompiler CPU.c
@@ -174,11 +174,9 @@ BYTE * Compiler4300iBlock(void) {
 	} else if (StartAddress >= 0x1FC00000 && StartAddress <= 0x1FC00800) {
 		CPU_Message("====== PIF ROM: block ======");
 	} else {
-#ifndef ROM_IN_MAPSPACE
 		if (ShowDebugMessages)
 			DisplayError("Ummm... Where does this block go");
 		ExitThread(0);			
-#endif
 	}
 	CPU_Message("x86 code at: %X",BlockInfo.CompiledLocation);
 	CPU_Message("Start of Block: %X",BlockInfo.StartVAddr );
@@ -262,11 +260,9 @@ BYTE * CompileDelaySlot(void) {
 	} else if (StartAddress >= 0x1FC00000 && StartAddress <= 0x1FC00800) {
 		CPU_Message("====== PIF ROM: Delay Slot ======");
 	} else {
-#ifndef ROM_IN_MAPSPACE
 		if (ShowDebugMessages)
 			DisplayError("Ummm... Where does this block go");
 		ExitThread(0);
-#endif
 	}
 	MarkCodeBlock(StartAddress);
 	CPU_Message("x86 code at: %X",Block);
@@ -2943,12 +2939,10 @@ void MarkCodeBlock (DWORD PAddr) {
 	} else if (PAddr >= 0x1FC00000 && PAddr <= 0x1FC00800) {
 		N64_Blocks.NoOfPifRomBlocks += 1;
 	} else {
-#ifndef ROM_IN_MAPSPACE
 		if (ShowDebugMessages)
 			DisplayError("Ummm... Which code block should be marked on\nPC = 0x%08X\nRdramSize: %X",PAddr,RdramSize);
 
 		ExitThread(0);
-#endif
 	}
 }
 

--- a/Rom.h
+++ b/Rom.h
@@ -35,7 +35,7 @@ extern "C" {
 	extern BYTE RomHeader[0x1000];
 	extern DWORD PrevCRC1, PrevCRC2;
 
-
+	void CloseTempRomFile(void);
 	void AddRecentFile(HWND hWnd, char* addition);
 	BOOL LoadDataFromRomFile(char* FileName, BYTE* Data, int DataLen, int* RomSize);
 	BOOL LoadRomHeader(void);


### PR DESCRIPTION
This saves a lot of heap space by memory mapping the ROM (the memory is file-backed) instead of retaining the entire file contents on the heap.

It has to create a temporary file because it can't map compressed data (from a zip file) and the entire emulator and plugin ecosystem expects the ROM to be stored in little endian. There's also a little hidden hack for Aleck64 games that patches the ROM contents...

As a bonus, the memory mapped file is always read-only. See `FILE_MAP_READ` documentation in
https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile This allows removing several VirtualProtect() calls.

----

Here's what the change looks like from the system's virtual memory point of view, using Conker's Bad Fur Day (one of the largest commercial ROMs):

Before:

![conker-heap-before](https://github.com/pj64team/Project64-Legacy/assets/456942/c700947d-8abb-4875-8c24-d7d4acf93dc4)

After:

![conker-heap-after](https://github.com/pj64team/Project64-Legacy/assets/456942/8355e5da-1cee-4003-9f75-62d5c2f207c2)

The difference is primarily that `Heap` shrunk and `Mapped File` grew accordingly.

If you prefer a simpler view of memory, here's what it looks like in task manager (I paused emulation at about the same place in the intro for each screenshot, so CPU is around 0%):

Before:

![conker-mem-before](https://github.com/pj64team/Project64-Legacy/assets/456942/b3213d1d-d9e7-4db0-96fc-d5f207991049)

After:

![conker-mem-after](https://github.com/pj64team/Project64-Legacy/assets/456942/8499d4e7-8591-42df-b29e-a24af2657296)

----

See also #41 where memory allocation failures were observed for "large" allocations (64 MB). That PR addressed allocations with the cheat search. This one addresses a similarly large allocation with the ROM file.