### PR TITLE
Reduce large contiguous heap allocations

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -1103,7 +1103,7 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 					}
 
 					CloseCpu();
-					CloseTempRomFile();
+					CloseMappedRomFile();
 					hMenu = GetMenu(hMainWindow);
 					EnableMenuItem(hMenu, ID_FILE_STARTEMULATION, MFS_ENABLED | MF_BYCOMMAND);
 					if (DrawScreen != NULL) 

--- a/Memory.c
+++ b/Memory.c
@@ -47,13 +47,6 @@ BYTE ISViewerBuffer[0x200];
 BYTE ISViewerTempBuffer[0x1000+0x200+1];
 DWORD ISViewerTempBufferLength;
 
-int Allocate_ROM ( void ) {	
-	ROM = (BYTE *)malloc(RomFileSize);
-	WrittenToRom = FALSE;
-	WrittenToRomCount = 0;
-	return ROM == NULL ? FALSE : TRUE;
-}
-
 int Allocate_Memory ( void ) {	
 	RdramSize = 0x400000;
 	
@@ -2635,7 +2628,7 @@ BOOL r4300i_SW_VAddr_NonCPU ( DWORD VAddr, DWORD Value ) {
 void Release_Memory ( void ) {
 	FreeSyncMemory();
 	if (OrigMem != NULL) { VirtualFree(OrigMem,0,MEM_RELEASE); }
-	CloseTempRomFile();
+	CloseMappedRomFile();
 	VirtualFree( TLB_ReadMap, 0 , MEM_RELEASE);
 	VirtualFree( TLB_WriteMap, 0 , MEM_RELEASE);
 	VirtualFree( N64MEM, 0 , MEM_RELEASE);

--- a/Memory.h
+++ b/Memory.h
@@ -37,7 +37,6 @@ extern DWORD WroteToRom;
 extern BYTE ISViewerBuffer[0x200];
 
 /* Memory Control */
-int  Allocate_ROM                ( void );
 int  Allocate_Memory             ( void );	
 void Release_Memory              ( void );
 

--- a/Rom.c
+++ b/Rom.c
@@ -41,14 +41,15 @@
 #define MenuLocOfUsedFiles	12
 #define MenuLocOfUsedDirs	(MenuLocOfUsedFiles + 1)
 
-DWORD RomFileSize;
+DWORD RomFileSize = 0;
 int RomRamSize, RomSaveUsing, RomCPUType, RomSelfMod,
 RomUseTlb, RomUseLinking, RomCF, RomUseLargeBuffer, RomUseCache,
 RomDelaySI, RomSPHack, RomAudioSignal, RomEmulateAI, RomModVIS;
 char CurrentFileName[MAX_PATH + 1] = { "" }, RomName[MAX_PATH + 1] = { "" }, RomFullName[MAX_PATH + 1] = { "" };
 char LastRoms[10][MAX_PATH + 1], LastDirs[10][MAX_PATH + 1];
 BYTE RomHeader[0x1000];
-DWORD CRC_SRC_SIZE = 0x00101000;
+const DWORD CRC_SRC_SIZE = 0x00101000;
+const BYTE ZEROS[4096] = { 0 };
 DWORD PrevCRC1, PrevCRC2;
 HANDLE hRomFile = NULL;
 HANDLE hRomMapping = NULL;
@@ -103,67 +104,51 @@ void AddRecentFile(HWND hWnd, char* addition) {
 	SetupMenu(hMainWindow);
 }
 
-// Create a temporary file for the unzipped/byte-swapped/patched ROM. Takes ownership of the `ROM` global.
-// The temporary file can be closed and deleted with `CloseTempRomFile()`
-BOOL CreateTempRomFile(void) {
+// Create a temporary file for the unzipped/byte-swapped/patched ROM.
+// Expects the `RomFileSize` global to have been initialized correctly.
+// Initializes the `ROM` global as a memory-mapped file.
+// The temporary file can be closed and deleted with `CloseMappedRomFile()`
+BOOL CreateMappedRomFile(void) {
+	if (RomFileSize == 0) {
+		return FALSE;
+	}
+
 	char temp_path[_MAX_PATH + 1] = { 0 };
 	char temp_file[_MAX_PATH + 1] = { 0 };
 
 	if (GetTempPath(_MAX_PATH, temp_path) == 0) {
-		free(ROM);
-		ROM = NULL;
 		return FALSE;
 	}
 
 	if (GetTempFileName(temp_path, "PJ64", 0, temp_file) == 0) {
-		free(ROM);
-		ROM = NULL;
 		return FALSE;
 	}
 
-	// Create the file and write ROM to it
-	hRomFile = CreateFile(temp_file, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
-		FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_TEMPORARY, NULL);
-	if (hRomFile == INVALID_HANDLE_VALUE) {
-		free(ROM);
-		ROM = NULL;
-		return FALSE;
-	}
-
-	DWORD bytes_written = 0;
-	if (WriteFile(hRomFile, ROM, RomFileSize, &bytes_written, NULL) == FALSE) {
-		free(ROM);
-		ROM = NULL;
-		CloseHandle(hRomFile);
-		DeleteFile(temp_file);
-		return FALSE;
-	}
-	free(ROM);
-	ROM = NULL;
-	if (bytes_written != RomFileSize) {
-		CloseHandle(hRomFile);
-		DeleteFile(temp_file);
-		return FALSE;
-	}
-
-	// Reopen the file read-only
-	CloseHandle(hRomFile);
-	hRomFile = CreateFile(temp_file, GENERIC_READ, 0, NULL, OPEN_EXISTING,
+	// Create the file
+	hRomFile = CreateFile(temp_file, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
 		FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE | FILE_FLAG_RANDOM_ACCESS, NULL);
 	if (hRomFile == INVALID_HANDLE_VALUE) {
-		CloseHandle(hRomFile);
 		DeleteFile(temp_file);
 		return FALSE;
+	}
+
+	// Zero out the file
+	for (DWORD i = 0; i < RomFileSize; i += sizeof(ZEROS)) {
+		DWORD written = 0;
+		if (WriteFile(hRomFile, ZEROS, sizeof(ZEROS), &written, NULL) == FALSE || written != sizeof(ZEROS)) {
+			CloseHandle(hRomFile);
+			return FALSE;
+		}
 	}
 
 	// Map the file into memory
-	hRomMapping = CreateFileMapping(hRomFile, NULL, PAGE_READONLY, 0, 0, NULL);
+	hRomMapping = CreateFileMapping(hRomFile, NULL, PAGE_READWRITE, 0, RomFileSize, NULL);
 	if (hRomMapping == NULL) {
 		CloseHandle(hRomFile);
 		return FALSE;
 	}
 
-	ROM = MapViewOfFile(hRomMapping, FILE_MAP_READ, 0, 0, 0);
+	ROM = MapViewOfFile(hRomMapping, FILE_MAP_WRITE, 0, 0, 0);
 	if (ROM == NULL) {
 		CloseHandle(hRomMapping);
 		CloseHandle(hRomFile);
@@ -175,7 +160,7 @@ BOOL CreateTempRomFile(void) {
 
 // Close the temporary ROM file.
 // The file will be deleted automatically by the system when closed.
-void CloseTempRomFile(void) {
+void CloseMappedRomFile(void) {
 	if (ROM != NULL && hRomFile != NULL && hRomMapping != NULL) {
 		UnmapViewOfFile(ROM);
 		CloseHandle(hRomMapping);
@@ -184,6 +169,7 @@ void CloseTempRomFile(void) {
 		ROM = NULL;
 		hRomMapping = NULL;
 		hRomFile = NULL;
+		RomFileSize = 0;
 	}
 }
 
@@ -513,7 +499,6 @@ void LoadRecentRom(DWORD Index) {
 BOOL LoadRomHeader(void) {
 	char drive[_MAX_DRIVE], FileName[_MAX_DIR], dir[_MAX_DIR], ext[_MAX_EXT];
 	BYTE Test[4];
-	int count;
 
 	if (_strnicmp(&CurrentFileName[strlen(CurrentFileName) - 4], ".ZIP", 4) == 0) {
 		int port = 0, FoundRom;
@@ -830,7 +815,6 @@ void SetNewFileDirectory(void) {
 }
 
 DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
-#define ReadFromRomSection	0x40000000 // Adjusted from 40000 to 400000
 	char drive[_MAX_DRIVE], FileName[_MAX_DIR], dir[_MAX_DIR], ext[_MAX_EXT];
 	char WinTitle[300], MapFile[_MAX_PATH];
 	char Message[100];
@@ -862,6 +846,9 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		ResetMappings();
 	SetNewFileDirectory();
 	strcpy(MapFile, CurrentFileName);
+
+	SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)GS(MSG_LOADING));
+
 	if (_strnicmp(&CurrentFileName[strlen(CurrentFileName) - 4], ".ZIP", 4) == 0) {
 		int len, port = 0, FoundRom;
 		unz_file_info info;
@@ -869,6 +856,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		unzFile file;
 		file = unzOpen(CurrentFileName);
 		if (file == NULL) {
+			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 			DisplayError(GS(MSG_FAIL_OPEN_ZIP));
 			EnableOpenMenuItems();
 			ShowRomList(hMainWindow);
@@ -880,6 +868,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		while (port == UNZ_OK && FoundRom == FALSE) {
 			unzGetCurrentFileInfo(file, &info, zname, 128, NULL, 0, NULL, 0);
 			if (unzLocateFile(file, zname, 1) != UNZ_OK) {
+				SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 				unzClose(file);
 				DisplayError(GS(MSG_FAIL_ZIP));
 				EnableOpenMenuItems();
@@ -887,6 +876,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 				return 0;
 			}
 			if (unzOpenCurrentFile(file) != UNZ_OK) {
+				SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 				unzClose(file);
 				DisplayError(GS(MSG_FAIL_OPEN_ZIP));
 				EnableOpenMenuItems();
@@ -896,26 +886,24 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 			unzReadCurrentFile(file, Test, 4);
 			if (IsValidRomImage(Test)) {
 				FoundRom = TRUE;
+
+				// Create a temporary file for memory-mapping the ROM
 				RomFileSize = info.uncompressed_size;
-				if (!Allocate_ROM()) {
+				if (CreateMappedRomFile() == FALSE) {
+					SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 					unzCloseCurrentFile(file);
 					unzClose(file);
-					DisplayError(GS(MSG_MEM_ALLOC_ERROR));
+					DisplayError(GS(MSG_FAIL_CREATE_TEMP));
 					EnableOpenMenuItems();
 					ShowRomList(hMainWindow);
 					return 0;
 				}
+
 				memcpy(ROM, Test, 4);
-				//len = unzReadCurrentFile(file,&ROM[4],RomFileSize - 4) + 4;
-				len = 4;
-				for (count = 4; count < (int)RomFileSize; count += ReadFromRomSection) {
-					len += unzReadCurrentFile(file, &ROM[count], ReadFromRomSection);
-					sprintf(Message, "%s: %.2f%c", GS(MSG_LOADED), ((float)len / (float)RomFileSize) * 100.0f, '%');
-					SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)Message);
-					Sleep(10); // Adjusted down to 10ms from 100ms
-				}
+				len = unzReadCurrentFile(file, &ROM[4], RomFileSize - 4) + 4;
 				if ((int)RomFileSize != len) {
-					free(ROM);
+					SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
+					CloseMappedRomFile();
 					unzCloseCurrentFile(file);
 					unzClose(file);
 					switch (len) {
@@ -933,7 +921,8 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 					return 0;
 				}
 				if (unzCloseCurrentFile(file) == UNZ_CRCERROR) {
-					free(ROM);
+					SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
+					CloseMappedRomFile();
 					unzClose(file);
 					DisplayError(GS(MSG_FAIL_OPEN_ZIP));
 					EnableOpenMenuItems();
@@ -950,7 +939,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 			}
 		}
 		if (FoundRom == FALSE) {
-			free(ROM);
+			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 			DisplayError(GS(MSG_FAIL_OPEN_ZIP));
 			unzClose(file);
 			EnableOpenMenuItems();
@@ -962,7 +951,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		}
 	}
 	else {
-		DWORD dwRead, dwToRead, TotalRead;
+		DWORD dwRead;
 		HANDLE hFile;
 
 		hFile = CreateFile(CurrentFileName, GENERIC_READ, FILE_SHARE_READ, NULL,
@@ -978,8 +967,7 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		}
 
 		SetFilePointer(hFile, 0, 0, FILE_BEGIN);
-		ReadFile(hFile, Test, 4, &dwRead, NULL);
-		if (!IsValidRomImage(Test)) {
+		if (!ReadFile(hFile, Test, 4, &dwRead, NULL) || !IsValidRomImage(Test)) {
 			CloseHandle(hFile);
 			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 			DisplayError(GS(MSG_FAIL_IMAGE));
@@ -987,43 +975,21 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 			ShowRomList(hMainWindow);
 			return 0;
 		}
-		RomFileSize = GetFileSize(hFile, NULL);
 
-		if (!Allocate_ROM()) {
-			CloseHandle(hFile);
+		// Create a temporary file for memory-mapping the ROM
+		RomFileSize = GetFileSize(hFile, NULL);
+		if (CreateMappedRomFile() == FALSE) {
 			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
-			DisplayError(GS(MSG_MEM_ALLOC_ERROR));
+			DisplayError(GS(MSG_FAIL_CREATE_TEMP));
 			EnableOpenMenuItems();
 			ShowRomList(hMainWindow);
 			return 0;
 		}
 
-		SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)GS(MSG_LOADING));
 		SetFilePointer(hFile, 0, 0, FILE_BEGIN);
 
-		TotalRead = 0;
-		for (count = 0; count < (int)RomFileSize; count += ReadFromRomSection) {
-			dwToRead = RomFileSize - count;
-			if (dwToRead > ReadFromRomSection) { dwToRead = ReadFromRomSection; }
-
-			if (!ReadFile(hFile, &ROM[count], dwToRead, &dwRead, NULL)) {
-				free(ROM);
-				CloseHandle(hFile);
-				SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
-				DisplayError(GS(MSG_FAIL_OPEN_IMAGE));
-				EnableOpenMenuItems();
-				ShowRomList(hMainWindow);
-				return 0;
-			}
-			TotalRead += dwRead;
-			sprintf(Message, "%s: %.2f%c", GS(MSG_LOADED), ((float)TotalRead / (float)RomFileSize) * 100.0f, '%');
-			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)Message);
-			Sleep(10); // Adjusted down to 10ms from 100ms
-		}
-		dwRead = TotalRead;
-
-		if (RomFileSize != dwRead) {
-			free(ROM);
+		if (!ReadFile(hFile, ROM, RomFileSize, &dwRead, NULL) || RomFileSize != dwRead) {
+			CloseMappedRomFile();
 			CloseHandle(hFile);
 			SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
 			DisplayError(GS(MSG_FAIL_OPEN_IMAGE));
@@ -1049,14 +1015,6 @@ DWORD WINAPI OpenChosenFile(LPVOID lpArgs) {
 		ROM[0x67d] = 0;
 		ROM[0x67e] = 0;
 		ROM[0x67f] = 0;
-	}
-
-	// Write unzipped/byte-swapped/patched ROM to a temporary file
-	if (CreateTempRomFile() == FALSE) {
-		SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
-		DisplayError(GS(MSG_FAIL_CREATE_TEMP));
-		EnableOpenMenuItems();
-		ShowRomList(hMainWindow);
 	}
 
 	SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
@@ -1349,7 +1307,7 @@ void RecalculateCRCs(BYTE* data, DWORD data_size) {
 
 void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 	BYTE* data = NULL;
-	DWORD data_size = 0, count;
+	DWORD data_size = 0;
 
 	// As much as this pains me, this is mostly a copy of code that already exists as a copy and paste nightmare
 	// Some of the code has been reduced because the checks have already been performed
@@ -1398,12 +1356,9 @@ void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 					return;
 				}
 				memcpy(data, Test, 4);
-				//len = unzReadCurrentFile(file,&ROM[4],RomFileSize - 4) + 4;
-				len = 4;
-				for (count = 4; count < data_size; count += ReadFromRomSection) {
-					len += unzReadCurrentFile(file, &data[count], ReadFromRomSection);
-				}
+				len = unzReadCurrentFile(file, &ROM[4], RomFileSize - 4) + 4;
 				if ((int)data_size != len) {
+					free(data);
 					unzCloseCurrentFile(file);
 					unzClose(file);
 					switch (len) {
@@ -1419,6 +1374,7 @@ void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 					return;
 				}
 				if (unzCloseCurrentFile(file) == UNZ_CRCERROR) {
+					free(data);
 					unzClose(file);
 					DisplayError(GS(MSG_FAIL_OPEN_ZIP));
 					return;
@@ -1437,7 +1393,7 @@ void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 		}
 	}
 	else {
-		DWORD dwRead, dwToRead, TotalRead;
+		DWORD dwRead;
 		HANDLE hFile;
 		BYTE Test[4];
 
@@ -1468,22 +1424,8 @@ void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 
 		SetFilePointer(hFile, 0, 0, FILE_BEGIN);
 
-		TotalRead = 0;
-		for (count = 0; count < data_size; count += ReadFromRomSection) {
-			dwToRead = data_size - count;
-			if (dwToRead > ReadFromRomSection) { dwToRead = ReadFromRomSection; }
-
-			if (!ReadFile(hFile, &data[count], dwToRead, &dwRead, NULL)) {
-				CloseHandle(hFile);
-				SendMessage(hStatusWnd, SB_SETTEXT, 0, (LPARAM)"");
-				DisplayError(GS(MSG_FAIL_OPEN_IMAGE));
-				return;
-			}
-			TotalRead += dwRead;
-		}
-		dwRead = TotalRead;
-
-		if (data_size != dwRead) {
+		if (!ReadFile(hFile, data, data_size, &dwRead, NULL) || data_size != dwRead) {
+			free(data);
 			CloseHandle(hFile);
 			DisplayError(GS(MSG_FAIL_OPEN_IMAGE));
 			return;
@@ -1500,8 +1442,7 @@ void LoadRomRecalcCRCs(char* FileName, BYTE* CRC1, BYTE* CRC2) {
 	*(DWORD*)CRC2 = *(DWORD*)&data[0x14];
 
 	// Make sure to free allocated space
-	if (data != NULL)
-		free(data);
+	free(data);
 }
 
 // This was a test, unzipping is a limiting factor when calculating the xxhash

--- a/Rom.h
+++ b/Rom.h
@@ -35,7 +35,7 @@ extern "C" {
 	extern BYTE RomHeader[0x1000];
 	extern DWORD PrevCRC1, PrevCRC2;
 
-	void CloseTempRomFile(void);
+	void CloseMappedRomFile(void);
 	void AddRecentFile(HWND hWnd, char* addition);
 	BOOL LoadDataFromRomFile(char* FileName, BYTE* Data, int DataLen, int* RomSize);
 	BOOL LoadRomHeader(void);


### PR DESCRIPTION
We don't need to allocate space for the entire ROM. Just the 1MB (and change) needed for the CRCs.

We also do not need to allocate any memory at all for playing the ROM. We have a memory mapped file for that. The biggest chunk of this PR migrates fully to the memory mapped file with no heap allocation.
 
Fixes the "unable to allocate memory" error when loading Conker or RE2.

The driving factor for these changes seems to be the nvidia driver (it's 50 MB!!). The driver takes a massive contiguous block of our virtual address space, so we need to be careful about the number of large allocation blocks. The ROM file is definitely the largest contiguous block that the emulator would allocate. The next largest blocks are used for storing temporary cheat results (See #41 for background). These can also use memory mapped files if they become a problem.