### PR TITLE
Delay save state until rsp is halted

### DIFF
--- a/Cpu.c
+++ b/Cpu.c
@@ -528,7 +528,7 @@ void DoSomething ( void ) {
 	}
 	CPU_Action.DoSomething = FALSE;
 	
-	if (CPU_Action.SaveState) {
+	if (CPU_Action.SaveState && (SP_STATUS_REG & SP_STATUS_HALT) != 0) {
 		//test if allowed
 		CPU_Action.SaveState = FALSE;
 		if (!Machine_SaveState()) {

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -152,7 +152,7 @@ void BuildInterpreter (void ) {
 	R4300i_Opcode[57] = r4300i_SWC1;
 	R4300i_Opcode[58] = R4300i_UnknownOpcode;
 	R4300i_Opcode[59] = r4300i_RESERVED;
-	R4300i_Opcode[60] = R4300i_UnknownOpcode; // TODO: SCD
+	R4300i_Opcode[60] = r4300i_SCD;
 	R4300i_Opcode[61] = r4300i_SDC1;
 	R4300i_Opcode[62] = R4300i_UnknownOpcode;
 	R4300i_Opcode[63] = r4300i_SD;

--- a/Interpreter CPU.c
+++ b/Interpreter CPU.c
@@ -144,7 +144,7 @@ void BuildInterpreter (void ) {
 	R4300i_Opcode[49] = r4300i_LWC1;
 	R4300i_Opcode[50] = R4300i_UnknownOpcode;
 	R4300i_Opcode[51] = r4300i_RESERVED;
-	R4300i_Opcode[52] = R4300i_UnknownOpcode; // TODO: LLD
+	R4300i_Opcode[52] = r4300i_LLD;
 	R4300i_Opcode[53] = r4300i_LDC1;
 	R4300i_Opcode[54] = R4300i_UnknownOpcode;
 	R4300i_Opcode[55] = r4300i_LD;

--- a/Interpreter Ops.c
+++ b/Interpreter Ops.c
@@ -834,7 +834,7 @@ void _fastcall r4300i_LL (void) {
 void _fastcall r4300i_LLD(void) {
 	MIPS_DWORD Address;
 	Address.UDW = GPR[Opcode.IMM.base].UDW + (short)Opcode.IMM.immediate;
-	if ((Address.UW[0] & 3) != 0 || !IsSignExtended(Address)) {
+	if ((Address.UW[0] & 7) != 0 || !IsSignExtended(Address)) {
 		ADDRESS_ERROR_EXCEPTION(Address.UDW, TRUE);
 		return;
 	}
@@ -888,7 +888,26 @@ void _fastcall r4300i_SC (void) {
 			TLB_WRITE_EXCEPTION(Address.UW[0]);
 		}
 	}
-	GPR[Opcode.BRANCH.rt].UW[0] = LLBit;
+	GPR[Opcode.BRANCH.rt].UDW = LLBit;
+}
+
+void _fastcall r4300i_SCD(void) {
+	MIPS_DWORD Address;
+	Address.UDW = GPR[Opcode.IMM.base].UDW + (short)Opcode.IMM.immediate;
+	if ((Address.UW[0] & 7) != 0 || !IsSignExtended(Address)) {
+		ADDRESS_ERROR_EXCEPTION(Address.UDW, FALSE);
+		return;
+	}
+
+	if (LLBit == 1) {
+		if (!r4300i_SD_VAddr(Address.UW[0], GPR[Opcode.BRANCH.rt].UDW)) {
+			if (ShowTLBMisses) {
+				DisplayError("SW TLB: %X", Address.UW[0]);
+			}
+			TLB_WRITE_EXCEPTION(Address.UW[0]);
+		}
+	}
+	GPR[Opcode.BRANCH.rt].UDW = LLBit;
 }
 
 void _fastcall r4300i_LD (void) {

--- a/Interpreter Ops.c
+++ b/Interpreter Ops.c
@@ -1672,9 +1672,12 @@ void _fastcall r4300i_COP0_MT (void) {
 		} else {
 			CP0[Opcode.REG.rd].UW[0] = GPR[Opcode.BRANCH.rt].UW[0] & 0XFFF7FFFF;
 		}
-		if ((CP0[Opcode.REG.rd].UW[0] & 0x18) != 0) { 
+		if ((CP0[Opcode.REG.rd].UW[0] & STATUS_KSU) != STATUS_KERNEL) { 
 			if (ShowDebugMessages)
 				DisplayError("Left kernel mode ??");
+		}
+		if ((CP0[Opcode.REG.rd].UW[0] & STATUS_KX) != 0) {
+			DisplayError("Kernel mode with 64 bits mode");
 		}
 		CheckInterrupts();
 		break;		

--- a/Interpreter Ops.c
+++ b/Interpreter Ops.c
@@ -831,6 +831,28 @@ void _fastcall r4300i_LL (void) {
 	}
 }
 
+void _fastcall r4300i_LLD(void) {
+	MIPS_DWORD Address;
+	Address.UDW = GPR[Opcode.IMM.base].UDW + (short)Opcode.IMM.immediate;
+	if ((Address.UW[0] & 3) != 0 || !IsSignExtended(Address)) {
+		ADDRESS_ERROR_EXCEPTION(Address.UDW, TRUE);
+		return;
+	}
+
+	if (!r4300i_LD_VAddr(Address.UW[0], &GPR[Opcode.BRANCH.rt].UDW)) {
+		if (ShowTLBMisses) {
+			DisplayError("LL TLB: %X", Address.UW[0]);
+		}
+		TLB_READ_EXCEPTION(Address.UW[0]);
+	}
+	else {
+		LLBit = 1;
+		LLAddr = Address.UW[0];
+		TranslateVaddr(&LLAddr);
+		if (Opcode.BRANCH.rt == 0) { return; }
+	}
+}
+
 void _fastcall r4300i_LWC1 (void) {
 	MIPS_DWORD Address;
 	Address.UDW = GPR[Opcode.IMM.base].UDW + (short)Opcode.IMM.immediate;

--- a/Interpreter Ops.c
+++ b/Interpreter Ops.c
@@ -1677,7 +1677,7 @@ void _fastcall r4300i_COP0_MT (void) {
 				DisplayError("Left kernel mode ??");
 		}
 		if ((CP0[Opcode.REG.rd].UW[0] & STATUS_KX) != 0) {
-			DisplayError("Kernel mode with 64 bits mode");
+			LogMessage("Kernel mode with 64 bits mode");
 		}
 		CheckInterrupts();
 		break;		

--- a/Interpreter Ops.h
+++ b/Interpreter Ops.h
@@ -65,6 +65,7 @@ void _fastcall r4300i_SWR            ( void );
 void _fastcall r4300i_CACHE          ( void );
 void _fastcall r4300i_LL             ( void );
 void _fastcall r4300i_LWC1           ( void );
+void _fastcall r4300i_LLD            ( void );
 void _fastcall r4300i_LDC1           ( void );
 void _fastcall r4300i_LD             ( void );
 void _fastcall r4300i_SC             ( void );

--- a/Interpreter Ops.h
+++ b/Interpreter Ops.h
@@ -70,6 +70,7 @@ void _fastcall r4300i_LDC1           ( void );
 void _fastcall r4300i_LD             ( void );
 void _fastcall r4300i_SC             ( void );
 void _fastcall r4300i_SWC1           ( void );
+void _fastcall r4300i_SCD            ( void );
 void _fastcall r4300i_SDC1           ( void );
 void _fastcall r4300i_SD             ( void );
 

--- a/Main.c
+++ b/Main.c
@@ -1144,7 +1144,7 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 					break;
 
 				case ID_CPU_SAVE:
-					if (CPU_Paused) {
+					if (CPU_Paused && (SP_STATUS_REG & SP_STATUS_HALT) != 0) {
 						if (!Machine_SaveState()) {
 							CPU_Action.SaveState = TRUE;
 							CPU_Action.DoSomething = TRUE;
@@ -1186,7 +1186,7 @@ LRESULT CALLBACK Main_Proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 						}
 
 						strcpy(SaveAsFileName, SaveFile);
-						if (CPU_Paused) {
+						if (CPU_Paused && (SP_STATUS_REG & SP_STATUS_HALT) != 0) {
 							if (!Machine_SaveState()) {
 								CPU_Action.SaveState = TRUE;
 								CPU_Action.DoSomething = TRUE;

--- a/Memory.c
+++ b/Memory.c
@@ -1440,9 +1440,7 @@ BOOL r4300i_LB_VAddr ( DWORD VAddr, BYTE * Value ) {
 	}
 	else {
 		DWORD DValue = 0;
-		if (!r4300i_LB_NonMemory(PAddr^3, &DValue, FALSE)) {
-			return FALSE;
-		}
+		r4300i_LB_NonMemory(PAddr ^ 3, &DValue, FALSE);
 		*Value = (BYTE)DValue;
 	}
 	return TRUE;
@@ -1480,13 +1478,9 @@ BOOL r4300i_LD_VAddr ( DWORD VAddr, unsigned _int64 * Value ) {
 	}
 	else {
 		DWORD DValue = 0;
-		if (!r4300i_LW_NonMemory(PAddr, &DValue)) {
-			return FALSE;
-		}
+		r4300i_LW_NonMemory(PAddr, &DValue);
 		*((DWORD*)(Value)+1) = DValue;
-		if (!r4300i_LW_NonMemory(PAddr+4, &DValue)) {
-			return FALSE;
-		}
+		r4300i_LW_NonMemory(PAddr + 4, &DValue);
 		*((DWORD*)(Value)) = DValue;
 	}
 	return TRUE;
@@ -1568,9 +1562,7 @@ BOOL r4300i_LH_VAddr ( DWORD VAddr, WORD * Value ) {
 	}
 	else {
 		DWORD DValue = 0;
-		if (!r4300i_LH_NonMemory(PAddr^2, &DValue, FALSE)) {
-			return FALSE;
-		}
+		r4300i_LH_NonMemory(PAddr ^ 2, &DValue, FALSE);
 		*Value = (WORD)DValue;
 	}
 	return TRUE;
@@ -1864,8 +1856,8 @@ BOOL r4300i_LW_VAddr ( DWORD VAddr, DWORD * Value ) {
 	if (PAddr < RdramSize || (PAddr >= 0x04000000 && PAddr < 0x04002000)) {
 		*Value = *(DWORD*)(TLB_ReadMap[VAddr >> 12] + VAddr);
 	}
-	else if (!r4300i_LW_NonMemory(PAddr, Value)) {
-		return FALSE;
+	else {
+		r4300i_LW_NonMemory(PAddr, Value);
 	}
 	return TRUE;
 }

--- a/Registers.c
+++ b/Registers.c
@@ -1349,7 +1349,8 @@ void UpdateCurrentHalfLine (void) {
 		HalfLine = 0;
 		return;
 	}
-    if (Timers.Timer < 0) { 
+    if (Timers.Timer < 0) {
+		//LogMessage("negative timer");
 		HalfLine = 0;
 		return;
 	}

--- a/Registers.h
+++ b/Registers.h
@@ -169,6 +169,13 @@
 #define STATUS_IE				0x00000001
 #define STATUS_EXL				0x00000002
 #define STATUS_ERL				0x00000004
+#define STATUS_KSU              0x00000018
+#define STATUS_KERNEL           0x00000000
+#define STATUS_SUPERVISOR       0x00000008
+#define STATUS_USER             0x00000010
+#define STATUS_UX               0x00000020
+#define STATUS_SX               0x00000040
+#define STATUS_KX               0x00000080
 #define STATUS_SR				0x00100000	// Soft Reset Signal caused exception
 #define STATUS_BEV				0x00400000
 #define STATUS_FR				0x04000000

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -1548,6 +1548,9 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 	case R4300i_SWC1:
 		sprintf(CommandName,"swc1\t%s, 0x%X (%s)",FPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
 		break;
+	case R4300i_SCD:
+		sprintf(CommandName, "scd\t%s, 0x%X (%s)", GPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
+		break;
 	case R4300i_SDC1:
 		sprintf(CommandName,"sdc1\t%s, 0x%X (%s)",FPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
 		break;

--- a/r4300i Commands.c
+++ b/r4300i Commands.c
@@ -1533,6 +1533,9 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 	case R4300i_LWC1:
 		sprintf(CommandName,"lwc1\t%s, 0x%X (%s)",FPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
 		break;
+	case R4300i_LLD:
+		sprintf(CommandName, "lld\t%s, 0x%X (%s)", GPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
+		break;
 	case R4300i_LDC1:
 		sprintf(CommandName,"ldc1\t%s, 0x%X (%s)",FPR_Name[command.BRANCH.rt], command.BRANCH.offset, GPR_Name[command.IMM.base]);
 		break;


### PR DESCRIPTION
The reason behind this is preventing to have a save state that depends on the rsp state as this is isolated in the plugin. We will need an architecture change at some point to handle this cleanly.